### PR TITLE
Makes known modules/categories case insensitive

### DIFF
--- a/usort/config.py
+++ b/usort/config.py
@@ -22,7 +22,7 @@ CAT_THIRD_PARTY = Category("third_party")
 def known_factory() -> Dict[str, Category]:
     known = {}
     for name in STDLIB_TOP_LEVEL_NAMES:
-        known[name] = CAT_STANDARD_LIBRARY
+        known[name.casefold()] = CAT_STANDARD_LIBRARY
 
     # This is also in the stdlib list, so this override comes last...
     known["__future__"] = CAT_FUTURE
@@ -32,6 +32,7 @@ def known_factory() -> Dict[str, Category]:
 
 @dataclass
 class Config:
+    # mapping of casefolded package names to categories
     known: Dict[str, Category] = field(default_factory=known_factory)
 
     # These names are vaguely for compatibility with isort; however while it has
@@ -99,7 +100,7 @@ class Config:
                 break
 
         if (p / "__init__.py").exists():
-            rv.known[p.name] = CAT_FIRST_PARTY
+            rv.known[p.name.casefold()] = CAT_FIRST_PARTY
 
         return rv
 
@@ -118,7 +119,7 @@ class Config:
                 raise ValueError(f"Known set for {cat} without it having an order")
 
             for name in names:
-                self.known[name] = typed_cat
+                self.known[name.casefold()] = typed_cat
 
         # "legacy" options
         for cat, option in [
@@ -129,7 +130,7 @@ class Config:
             if option in tbl:
                 for name in tbl[option]:
                     # TODO validate (no dots or whitespace, etc)
-                    self.known[name] = cat
+                    self.known[name.casefold()] = cat
 
     def update_from_flags(
         self,
@@ -151,7 +152,7 @@ class Config:
         ]:
             for name in option.split(","):
                 # TODO validate (no dots or whitespace, etc)
-                self.known[name] = cat
+                self.known[name.casefold()] = cat
 
     def category(self, dotted_import: str) -> Category:
         """
@@ -160,7 +161,7 @@ class Config:
         You can pass in ".foo" or "pkg.foo.bar" or just "os" and it should
         categorize.
         """
-        first_part = dotted_import.split(".")[0]
+        first_part = dotted_import.split(".")[0].casefold()
         if first_part == "":
             # relative import
             return CAT_FIRST_PARTY

--- a/usort/config.py
+++ b/usort/config.py
@@ -22,7 +22,7 @@ CAT_THIRD_PARTY = Category("third_party")
 def known_factory() -> Dict[str, Category]:
     known = {}
     for name in STDLIB_TOP_LEVEL_NAMES:
-        known[name.casefold()] = CAT_STANDARD_LIBRARY
+        known[name] = CAT_STANDARD_LIBRARY
 
     # This is also in the stdlib list, so this override comes last...
     known["__future__"] = CAT_FUTURE
@@ -32,7 +32,6 @@ def known_factory() -> Dict[str, Category]:
 
 @dataclass
 class Config:
-    # mapping of casefolded package names to categories
     known: Dict[str, Category] = field(default_factory=known_factory)
 
     # These names are vaguely for compatibility with isort; however while it has
@@ -100,7 +99,7 @@ class Config:
                 break
 
         if (p / "__init__.py").exists():
-            rv.known[p.name.casefold()] = CAT_FIRST_PARTY
+            rv.known[p.name] = CAT_FIRST_PARTY
 
         return rv
 
@@ -119,7 +118,7 @@ class Config:
                 raise ValueError(f"Known set for {cat} without it having an order")
 
             for name in names:
-                self.known[name.casefold()] = typed_cat
+                self.known[name] = typed_cat
 
         # "legacy" options
         for cat, option in [
@@ -130,7 +129,8 @@ class Config:
             if option in tbl:
                 for name in tbl[option]:
                     # TODO validate (no dots or whitespace, etc)
-                    self.known[name.casefold()] = cat
+                    assert "." not in name
+                    self.known[name] = cat
 
     def update_from_flags(
         self,
@@ -152,7 +152,8 @@ class Config:
         ]:
             for name in option.split(","):
                 # TODO validate (no dots or whitespace, etc)
-                self.known[name.casefold()] = cat
+                assert "." not in name
+                self.known[name] = cat
 
     def category(self, dotted_import: str) -> Category:
         """
@@ -161,7 +162,7 @@ class Config:
         You can pass in ".foo" or "pkg.foo.bar" or just "os" and it should
         categorize.
         """
-        first_part = dotted_import.split(".")[0].casefold()
+        first_part = dotted_import.split(".")[0]
         if first_part == "":
             # relative import
             return CAT_FIRST_PARTY

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -140,8 +140,8 @@ class SortableImport:
             assert first_dotted_import is not None
             return cls(
                 node=node,
-                first_module=first_module.lower(),
-                first_dotted_import=first_dotted_import.lower(),
+                first_module=first_module.casefold(),
+                first_dotted_import=first_dotted_import.casefold(),
                 imported_names=names,
                 config=config,
             )

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -28,6 +28,7 @@ class SortKey:
     category_index: int
     is_from_import: bool
     ndots: int
+    module: str
 
 
 @dataclass(order=True)
@@ -35,8 +36,9 @@ class SortableImport:
     node: cst.SimpleStatementLine = field(repr=False, compare=False)
     sort_key: SortKey = field(init=False)
 
-    # For constructing the sort key...
-    first_module: str
+    # For deciding what category
+    first_module: str = field(compare=False)
+    # For tiebreaking sort_key
     first_dotted_import: str
 
     config: Config = field(repr=False, compare=False)
@@ -59,6 +61,7 @@ class SortableImport:
             ),
             is_from_import=isinstance(self.node.body[0], cst.ImportFrom),
             ndots=ndots,
+            module=self.first_module.casefold(),
         )
 
     @classmethod
@@ -140,8 +143,8 @@ class SortableImport:
             assert first_dotted_import is not None
             return cls(
                 node=node,
-                first_module=first_module.casefold(),
-                first_dotted_import=first_dotted_import.casefold(),
+                first_module=first_module,
+                first_dotted_import=first_dotted_import,
                 imported_names=names,
                 config=config,
             )

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -276,6 +276,18 @@ from . import first_party
             ),
         )
 
+    def test_case_insensitive_sorting(self) -> None:
+        content = """\
+import calendar
+import cProfile
+import dataclasses
+
+from fissix.main import diff_texts
+from IPython import start_ipython
+from libcst import Module
+"""
+        self.assertEqual(content, usort_string(content, DEFAULT_CONFIG))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/usort/tests/sort_key.py
+++ b/usort/tests/sort_key.py
@@ -36,8 +36,8 @@ class SortableImportTest(unittest.TestCase):
         imp = SortableImport.from_node(
             cst.parse_statement("import IPython.core"), Config()
         )
-        self.assertEqual("ipython.core", imp.first_module)
-        self.assertEqual("ipython.core", imp.first_dotted_import)
+        self.assertEqual("IPython.core", imp.first_module)
+        self.assertEqual("IPython.core", imp.first_dotted_import)
         self.assertEqual({"IPython": "IPython"}, imp.imported_names)
 
     def test_from_node_ImportFrom(self) -> None:


### PR DESCRIPTION
This changes `Config.known` to a mapping of casefolded package names to
categories, which allows both case insensitive sorting and the ability
to treat "cProfile" as a part of stdlib. This would also allow, eg,
configuration that specifies "ipython" even though the import is
"IPython".

Fixes #26