### PR TITLE
Add configurable set of imports with side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+* Add support for configurable side-effect modules as block separators (#39)
+
 ## 0.5.0
 
 Initial public release

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -121,6 +121,8 @@ The following options are valid for the main ``tool.usort`` table:
     effects. Any module in this list will create implicit block separators from
     any import statement matching one of these modules.
 
+    See :ref:`side-effect-imports`.
+
 
 ``[tool.usort.known]``
 %%%%%%%%%%%%%%%%%%%%%%
@@ -205,6 +207,40 @@ will also create implicit block separators::
     from bar import *  # <-- implicit block separator
 
     import dog
+
+.. _side-effect-imports:
+
+Side Effect Imports
+^^^^^^^^^^^^^^^^^^^
+
+Writing modules with import-time side effects is a bad practice; any side
+effects should ideally wait for a function in that module to be called, like
+with :func:`warnings.filterwarnings()`. In these cases, µsort will correctly
+find and create a block separator, preventing accidental changes in execution
+order when sorting.
+
+However, it's common for testing libraries and entry points to have well-known
+side effects when imported, and this can cause trouble with import sorting.
+Rather than adding ``# usort:skip`` comments to every occurence, these modules
+can be added to the :attr:`side_effect_modules` configuration option:
+
+.. code-block:: toml
+    :name: pyproject.toml
+
+    [tool.usort]
+    side_effect_modules = ["sir_kibble"]
+
+µsort will then treat any import of these modules as implicit block separators::
+
+    import foo
+
+    from sir_kibble import leash  # <-- implicit block separator
+
+    import dog
+
+This may result in less-obvious sorting results for users unaware of the
+context, so it is recommended to use this sparingly. The ``list-imports``
+command may be useful for understanding how this affects your source files.
 
 
 Troubleshooting

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -82,29 +82,58 @@ Configuration
 -------------
 
 µsort shouldn't require configuration for most projects, but offers some basic
-options to customize sorting behaviors.  When using flags, only a few are
-available:
-
-* :attr:`known_standard_library: Set[str]`: A set of module names to treat
-  as part of the standard library. This is added to the set of modules listed
-  in the `stdlib_list <https://python-stdlib-list.readthedocs.io/en/latest/index.html>`_ package.
-
-* :attr:`known_third_party: Set[str]`: A set of module names to treat as
-  third-party modules.
-
-* :attr:`known_first_party: Set[str]`: A set of module names to treat as
-  first-party modules.
-
-* :attr:`default_section: str`: Which category should be used for unrecognized
-  module names. Valid values include ``"future"``, ``"standard_library"``,
-  ``"third_party"``, and ``"first_party"``. Defaults to ``"third_party"``.
+options to customize sorting and categorization behaviors.
 
 :file:`pyproject.toml`
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The preferred method of configuring µsort is in your project's
-:file:`pyproject.toml`, in the ``tool.usort`` section.  When you use this
-configuration, you may also come up with new category names:
+:file:`pyproject.toml`, in the ``tool.usort`` table.
+When sorting each file, µsort will look for the "nearest" :file:`pyproject.toml`
+to the file being sorted, looking upwards until the project root is found, or
+until the root of the filesystem is reached.
+
+``[tool.usort]``
+%%%%%%%%%%%%%%%%
+
+The following options are valid for the main ``tool.usort`` table:
+
+.. attribute:: categories
+    :type: List[str]
+    :value: ["future", "standard_library", "third_party", "first_party"]
+
+    If given, this list of categories overrides the default list of categories
+    that µsort provides. New categories may be added, but any of the default
+    categories *not* listed here will be removed.
+
+.. attribute:: default_section
+    :type: str
+    :value: "third_party"
+
+    The default category to classify any modules that aren't already known by
+    µsort as part of the standard library or otherwise listed in the
+    ``tool.usort.known`` table.
+
+.. attribute:: side_effect_modules
+    :type: List[str]
+
+    An optional list of known modules that have dangerous import-time side
+    effects. Any module in this list will create implicit block separators from
+    any import statement matching one of these modules.
+
+
+``[tool.usort.known]``
+%%%%%%%%%%%%%%%%%%%%%%
+
+The ``tool.usort.known`` table allows for providing a custom list of known
+modules for each category defined by :attr:`categories` above. These modules
+should be a list of module names assigned to a property named matching the
+category they should be assigned to. If a module is listed under multiple
+catergories, the last category it appears in will take precedence.
+
+As an example, this creates a fifth category "numpy", and adds both :mod:`numpy`
+and :mod:`pandas` to the known modules list for the "numpy" category, as well
+as adding the :mod:`example` module to the "first_party" category:
 
 .. code-block:: toml
 
@@ -114,11 +143,7 @@ configuration, you may also come up with new category names:
 
     [tool.usort.known]
     numpy = ["numpy", "pandas"]
-    first_party = ["something"]
-
-When run, µsort will look for the "nearest" :file:`pyproject.toml` to the
-current working directory, looking upwards until the project root is found,
-or until the root of the filesystem is reached.
+    first_party = ["example"]
 
 
 Import Blocks

--- a/usort/config.py
+++ b/usort/config.py
@@ -53,7 +53,7 @@ class Config:
 
     def __post_init__(self) -> None:
         self.side_effect_re = re.compile(
-            "|".join(m + r"\b" for m in self.side_effect_modules)
+            "|".join(re.escape(m) + r"\b" for m in self.side_effect_modules)
         )
 
     @classmethod

--- a/usort/config.py
+++ b/usort/config.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, NewType, Optional, Sequence
+from typing import Dict, List, NewType, Optional, Sequence
 
 import toml
 
@@ -30,6 +30,13 @@ def known_factory() -> Dict[str, Category]:
     return known
 
 
+def side_effect_factory() -> List[str]:
+    # TODO: define a list of common packages with known import-time side effects
+    known_side_effects: List[str] = []
+
+    return known_side_effects
+
+
 @dataclass
 class Config:
     known: Dict[str, Category] = field(default_factory=known_factory)
@@ -44,6 +51,10 @@ class Config:
         CAT_FIRST_PARTY,
     )
     default_section: Category = CAT_THIRD_PARTY
+
+    # Known set of modules with import side effects. These will be implicitly treated
+    # as block separators, similar to non-import statements.
+    side_effect_modules: List[str] = field(default_factory=side_effect_factory)
 
     @classmethod
     def find(cls, filename: Optional[Path] = None) -> "Config":
@@ -111,6 +122,8 @@ class Config:
             self.categories = [Category(x) for x in tbl["categories"]]
         if "default_section" in tbl:
             self.default_section = Category(tbl["default_section"])
+        if "side_effect_modules" in tbl:
+            self.side_effect_modules.extend(tbl["side_effect_modules"])
 
         for cat, names in tbl.get("known", {}).items():
             typed_cat = Category(cat)

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -221,7 +221,7 @@ def is_sortable_import(stmt: cst.CSTNode, config: Config) -> bool:
                 return False
             # avoid `from .` imports by checking for None, check everything else:
             #   from . import a -> module == None
-            #   from foo import bar -> module == Name(bar)
+            #   from foo import bar -> module == Name(foo)
             #   from a.b import c -> module == Attribute(Name(a), Name(b))
             elif stmt.body[0].module is not None:
                 base = cst.helpers.get_full_name_for_node_or_raise(stmt.body[0].module)

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -6,7 +6,7 @@
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import libcst as cst
 
@@ -199,23 +199,6 @@ def sortable_blocks(
     return ret
 
 
-def is_side_effect_import(base: str, names: List[str], config: Config) -> bool:
-    candidates: Set[str] = set()
-    if base:
-        parts = base.split(".")
-        candidates.update(".".join(parts[0:k]) for k in range(1, len(parts) + 1))
-        candidates.update(f"{base}.{name}" for name in names)
-    else:
-        for name in names:
-            parts = name.split(".")
-            candidates.update(".".join(parts[0:k]) for k in range(1, len(parts) + 1))
-
-    for candidate in candidates:
-        if candidate in config.side_effect_modules:
-            return True
-    return False
-
-
 def is_sortable_import(stmt: cst.CSTNode, config: Config) -> bool:
     if isinstance(stmt, cst.SimpleStatementLine):
         com = stmt.trailing_whitespace.comment
@@ -236,16 +219,20 @@ def is_sortable_import(stmt: cst.CSTNode, config: Config) -> bool:
             # `from x import *` is a barrier
             if isinstance(stmt.body[0].names, cst.ImportStar):
                 return False
+            # avoid `from .` imports by checking for None, check everything else:
+            #   from . import a -> module == None
+            #   from foo import bar -> module == Name(bar)
+            #   from a.b import c -> module == Attribute(Name(a), Name(b))
             elif stmt.body[0].module is not None:
                 base = cst.helpers.get_full_name_for_node_or_raise(stmt.body[0].module)
                 names = [name.evaluated_name for name in stmt.body[0].names]
-                if is_side_effect_import(base, names, config):
+                if config.is_side_effect_import(base, names):
                     return False
             return True
         elif isinstance(stmt.body[0], cst.Import):
             base = ""
             names = [name.evaluated_name for name in stmt.body[0].names]
-            if is_side_effect_import(base, names, config):
+            if config.is_side_effect_import(base, names):
                 return False
             return True
         else:

--- a/usort/tests/config.py
+++ b/usort/tests/config.py
@@ -119,7 +119,7 @@ foo = ["numpy", "pandas"]
         self.assertRegex("", config.side_effect_re)
 
         config = Config(side_effect_modules=["fizzbuzz", "foo.bar.baz"])
-        self.assertEqual(r"fizzbuzz\b|foo.bar.baz\b", config.side_effect_re.pattern)
+        self.assertEqual(r"fizzbuzz\b|foo\.bar\.baz\b", config.side_effect_re.pattern)
         self.assertNotRegex("", config.side_effect_re)
         self.assertRegex("fizzbuzz", config.side_effect_re)
         self.assertRegex("fizzbuzz.foo", config.side_effect_re)

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -5,6 +5,7 @@
 
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 
 from ..config import Config
@@ -287,6 +288,27 @@ from IPython import start_ipython
 from libcst import Module
 """
         self.assertEqual(content, usort_string(content, DEFAULT_CONFIG))
+
+    def test_side_effect_modules(self) -> None:
+        config = replace(
+            DEFAULT_CONFIG,
+            side_effect_modules=["tracemalloc", "fizzbuzz", "foo.bar.baz"],
+        )
+        content = """\
+from zipfile import ZipFile
+from tracemalloc import start
+from collections import defaultdict
+
+import fizzbuzz
+import attr
+import solar
+import foo.bar.baz
+from foo import bar
+from star import sun
+from foo.bar import baz
+from attr import evolve
+"""
+        self.assertEqual(content, usort_string(content, config))
 
 
 if __name__ == "__main__":

--- a/usort/tests/sort_key.py
+++ b/usort/tests/sort_key.py
@@ -8,7 +8,7 @@ import unittest
 import libcst as cst
 
 from ..config import Config
-from ..sorting import SortableImport, is_side_effect_import, is_sortable_import
+from ..sorting import SortableImport, is_sortable_import
 
 
 class SortableImportTest(unittest.TestCase):
@@ -89,25 +89,6 @@ class SortableImportTest(unittest.TestCase):
 
 
 class IsSortableTest(unittest.TestCase):
-    def test_is_side_effect(self) -> None:
-        config = Config(side_effect_modules=["fizzbuzz", "foo.bar.baz"])
-        # import foo, bar
-        self.assertFalse(is_side_effect_import("", ["foo", "bar"], config))
-        # from foo import bar
-        self.assertFalse(is_side_effect_import("foo", ["bar"], config))
-        # from foo.bar import foo
-        self.assertFalse(is_side_effect_import("foo.bar", ["foo"], config))
-        # from foo.bar import baz
-        self.assertTrue(is_side_effect_import("foo.bar", ["baz"], config))
-        # import foo.bar.baz
-        self.assertTrue(is_side_effect_import("", ["foo.bar.baz"], config))
-        # import fizzbuzz
-        self.assertTrue(is_side_effect_import("", ["fizzbuzz"], config))
-        # from fizzbuzz import a, b
-        self.assertTrue(is_side_effect_import("fizzbuzz", ["a", "b"], config))
-        # from fizzbuzz.apple import a, b
-        self.assertTrue(is_side_effect_import("fizzbuzz.apple", ["a", "b"], config))
-
     def test_is_sortable(self) -> None:
         self.assertTrue(is_sortable_import(cst.parse_statement("import a"), Config()))
         self.assertTrue(


### PR DESCRIPTION
When determining if imports are sortable, this adds some normalization,
and checks each part of the import name against the configured list
of known imports with side effects. If the full import, or any of the
combined stem parts, are in the configured list, then the import is
considered as unsortable, effectively creating an implicit barrier the
same way that `usort:skip` directives would.