### PR TITLE
Rename `default_section` to `default_category`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
 
 * Add support for configurable side-effect modules as block separators (#39)
+* Rename `default_section` option to `default_category` (#41)
 
 ## 0.5.0
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ venv:
 
 .PHONY: clean
 clean:
-	rm -rf dist html
+	rm -rf build dist html
 
 .PHONY: distclean
 distclean:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -106,7 +106,7 @@ The following options are valid for the main ``tool.usort`` table:
     that µsort provides. New categories may be added, but any of the default
     categories *not* listed here will be removed.
 
-.. attribute:: default_section
+.. attribute:: default_category
     :type: str
     :value: "third_party"
 
@@ -141,7 +141,7 @@ as adding the :mod:`example` module to the "first_party" category:
 
     [tool.usort]
     categories = ["future", "standard_library", numpy", "third_party", "first_party"]
-    default_section = "third_party"
+    default_category = "third_party"
 
     [tool.usort.known]
     numpy = ["numpy", "pandas"]

--- a/usort/config.py
+++ b/usort/config.py
@@ -44,7 +44,7 @@ class Config:
         CAT_THIRD_PARTY,
         CAT_FIRST_PARTY,
     )
-    default_section: Category = CAT_THIRD_PARTY
+    default_category: Category = CAT_THIRD_PARTY
 
     # Known set of modules with import side effects. These will be implicitly treated
     # as block separators, similar to non-import statements.
@@ -120,8 +120,8 @@ class Config:
 
         if "categories" in tbl:
             self.categories = [Category(x) for x in tbl["categories"]]
-        if "default_section" in tbl:
-            self.default_section = Category(tbl["default_section"])
+        if "default_category" in tbl:
+            self.default_category = Category(tbl["default_category"])
         if "side_effect_modules" in tbl:
             self.side_effect_modules.extend(tbl["side_effect_modules"])
 
@@ -154,12 +154,12 @@ class Config:
         known_third_party: str,
         known_standard_library: str,
         categories: str,
-        default_section: str,
+        default_category: str,
     ) -> None:
         if categories:
             self.categories = [Category(x) for x in categories.split(",")]
-        if default_section:
-            self.default_section = Category(default_section)
+        if default_category:
+            self.default_category = Category(default_category)
 
         for cat, option in [
             (CAT_FIRST_PARTY, known_first_party),
@@ -185,7 +185,7 @@ class Config:
         elif first_part in self.known:
             return self.known[first_part]
         else:
-            return self.default_section
+            return self.default_category
 
     def is_side_effect_import(self, base: str, names: List[str]) -> bool:
         """

--- a/usort/tests/config.py
+++ b/usort/tests/config.py
@@ -19,7 +19,7 @@ class ConfigTest(unittest.TestCase):
             (Path(d) / "pyproject.toml").write_text(
                 """\
 [tool.usort]
-default_section = "future"
+default_category = "future"
 """
             )
             conf = Config.find(Path(d))
@@ -30,7 +30,7 @@ default_section = "future"
             (Path(d) / "pyproject.toml").write_text(
                 """\
 [tool.usort]
-default_section = "future"
+default_category = "future"
 known_third_party = ["psutil", "cocoa"]
 """
             )
@@ -50,7 +50,7 @@ known_third_party = ["psutil", "cocoa"]
             (Path(d) / "pyproject.toml").write_text(
                 """\
 [tool.usort]
-default_section = "future"
+default_category = "future"
 [tool.usort.known]
 third_party = ["psutil", "cocoa"]
 """
@@ -107,7 +107,7 @@ foo = ["numpy", "pandas"]
             known_third_party="",
             known_standard_library="",
             categories="",
-            default_section="",
+            default_category="",
         )
         self.assertEqual(CAT_FIRST_PARTY, conf.known["a"])
         self.assertEqual(CAT_FIRST_PARTY, conf.known["b"])


### PR DESCRIPTION
Fixes #40: This option name was inconsistent with the use of "category",
so change the name to `default_category` to make it consistent.