### PR TITLE
Remove unused `update_from_flags` function

### DIFF
--- a/usort/config.py
+++ b/usort/config.py
@@ -148,29 +148,6 @@ class Config:
         # make sure generated regexes get updated
         self.__post_init__()
 
-    def update_from_flags(
-        self,
-        known_first_party: str,
-        known_third_party: str,
-        known_standard_library: str,
-        categories: str,
-        default_category: str,
-    ) -> None:
-        if categories:
-            self.categories = [Category(x) for x in categories.split(",")]
-        if default_category:
-            self.default_category = Category(default_category)
-
-        for cat, option in [
-            (CAT_FIRST_PARTY, known_first_party),
-            (CAT_THIRD_PARTY, known_third_party),
-            (CAT_STANDARD_LIBRARY, known_standard_library),
-        ]:
-            for name in option.split(","):
-                # TODO validate (no dots or whitespace, etc)
-                assert "." not in name
-                self.known[name] = cat
-
     def category(self, dotted_import: str) -> Category:
         """
         Given a piece of an import string, return its category for this config.

--- a/usort/tests/config.py
+++ b/usort/tests/config.py
@@ -100,18 +100,6 @@ foo = ["numpy", "pandas"]
             with self.assertRaisesRegex(ValueError, "Known set for foo"):
                 Config.find(Path(d) / "sample.py")
 
-    def test_from_flags(self) -> None:
-        conf = Config()
-        conf.update_from_flags(
-            known_first_party="a,b",
-            known_third_party="",
-            known_standard_library="",
-            categories="",
-            default_category="",
-        )
-        self.assertEqual(CAT_FIRST_PARTY, conf.known["a"])
-        self.assertEqual(CAT_FIRST_PARTY, conf.known["b"])
-
     def test_side_effect_init(self) -> None:
         config = Config()
         self.assertEqual([], config.side_effect_modules)


### PR DESCRIPTION
This isn't used anywhere from CLI; drop it for now and focus on using
pyproject.toml for configuration.