### PR TITLE
Better parsing error messages

### DIFF
--- a/usort/cli.py
+++ b/usort/cli.py
@@ -102,7 +102,7 @@ def check(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=False):
             if result.error:
-                click.echo(f"{result.error}")
+                click.echo(f"Error sorting {result.path}: {result.error}")
                 return_code |= 1
 
             if result.content != result.output:
@@ -127,7 +127,7 @@ def diff(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=False):
             if result.error:
-                click.echo(f"{result.error}")
+                click.echo(f"Error sorting {result.path}: {result.error}")
                 return_code |= 1
 
             if result.content != result.output:
@@ -161,7 +161,7 @@ def format(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=True):
             if result.error:
-                click.echo(f"{result.error}")
+                click.echo(f"Error sorting {result.path}: {result.error}")
                 return_code |= 1
                 continue
 

--- a/usort/cli.py
+++ b/usort/cli.py
@@ -102,7 +102,7 @@ def check(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=False):
             if result.error:
-                click.echo(f"Error on {result.path}: {result.error!r}")
+                click.echo(f"{result.error}")
                 return_code |= 1
 
             if result.content != result.output:
@@ -127,7 +127,7 @@ def diff(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=False):
             if result.error:
-                click.echo(f"Error on {result.path}: {result.error!r}")
+                click.echo(f"{result.error}")
                 return_code |= 1
 
             if result.content != result.output:
@@ -161,7 +161,7 @@ def format(filenames: List[str]) -> int:
         path = Path(f)
         for result in usort_path(path, write=True):
             if result.error:
-                click.echo(f"Error on {result.path}: {result.error!r}")
+                click.echo(f"{result.error}")
                 return_code |= 1
                 continue
 

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -294,6 +294,7 @@ def usort_path(path: Path, *, write: bool = False) -> Iterable[Result]:
     else:
         files = [path]
 
+    data: str = ""
     for f in files:
         try:
             config = Config.find(f.parent)

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -138,7 +138,7 @@ import os
 
         self.assertRegex(
             result.output,
-            r"Error parsing sample\.py:1 on 3\.\d+: `import` - Incomplete input",
+            r"Error sorting sample\.py: Syntax Error @ 1:7\.",
         )
         self.assertEqual(result.exit_code, 1)
 
@@ -151,7 +151,7 @@ import os
 
         self.assertRegex(
             result.output,
-            r"Error parsing sample\.py:2 on 3\.\d+: `print 'i'` - Incomplete input",
+            r"Error sorting sample\.py: Syntax Error @ 2:11\.",
         )
         self.assertEqual(result.exit_code, 1)
 

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -155,6 +155,23 @@ import os
         )
         self.assertEqual(result.exit_code, 1)
 
+    def test_format_permission_error(self) -> None:
+        """File does not have read permissions"""
+        with sample_contents("print('hello world')\n") as dtmp:
+            runner = CliRunner()
+            # make the file unreadable
+            (Path(dtmp) / "sample.py").chmod(0o000)
+            with chdir(dtmp):
+                result = runner.invoke(main, ["format", "."])
+            # restore permissions so that cleanup can succeed on windows
+            (Path(dtmp) / "sample.py").chmod(0o644)
+
+        self.assertRegex(
+            result.output,
+            r"Error sorting sample\.py: .+ Permission denied:",
+        )
+        self.assertEqual(result.exit_code, 1)
+
     def test_format_with_change(self) -> None:
         with sample_contents("import sys\nimport os\n") as dtmp:
             runner = CliRunner()

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -11,6 +11,7 @@ from typing import Generator
 
 import volatile
 from click.testing import CliRunner
+
 from usort.cli import main
 
 

--- a/usort/util.py
+++ b/usort/util.py
@@ -60,7 +60,6 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
 
     with timed(f"parsing {path}"):
         parse_error: Optional[cst.ParserSyntaxError] = None
-        parse_version: Optional[str] = None
 
         for version in cst.KNOWN_PYTHON_VERSION_STRINGS[::-1]:
             try:

--- a/usort/util.py
+++ b/usort/util.py
@@ -72,16 +72,5 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
                 # keep the first error we see in case parsing fails on all versions
                 if parse_error is None:
                     parse_error = e
-                    parse_version = version
 
-        if parse_error is None:
-            reason = f"Unknown error parsing {path}"
-        else:
-            context = parse_error.context or ""
-            context = context.rstrip("^").strip()
-            reason = (
-                f"Error parsing {path}:{parse_error.editor_line} on {parse_version}: "
-                f"`{context}` - {parse_error.message}"
-            )
-
-        raise Exception(reason)
+        raise parse_error or Exception("unknown parse failure")

--- a/usort/util.py
+++ b/usort/util.py
@@ -74,8 +74,14 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
                     parse_error = e
                     parse_version = version
 
-        context = parse_error.context.rstrip("^").strip()
-        raise Exception(
-            f"Error parsing {path}:{parse_error.editor_line} on {parse_version}: "
-            f"`{context}` - {parse_error.message}"
-        )
+        if parse_error is None:
+            reason = f"Unknown error parsing {path}"
+        else:
+            context = parse_error.context or ""
+            context = context.rstrip("^").strip()
+            reason = (
+                f"Error parsing {path}:{parse_error.editor_line} on {parse_version}: "
+                f"`{context}` - {parse_error.message}"
+            )
+
+        raise Exception(reason)

--- a/usort/util.py
+++ b/usort/util.py
@@ -72,4 +72,6 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
                 if parse_error is None:
                     parse_error = e
 
+        # not caring about existing traceback here because it's not useful for parse
+        # errors, and usort_path is already going to wrap it in a custom class
         raise parse_error or Exception("unknown parse failure")

--- a/usort/util.py
+++ b/usort/util.py
@@ -52,8 +52,8 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
     """
     Attempts to parse the file with all syntax versions known by LibCST.
 
-    If none parse, raises an exception that tells you that (what we know, not an
-    error that might not be the most helpful).
+    If parsing fails on all supported grammar versions, then raises the parser error
+    from the first/newest version attempted.
     """
     if data is None:
         data = path.read_bytes()


### PR DESCRIPTION
Rather than printing a raw exception with duplicate filename info, this just prints the exception message directly, and updates the exception message to be more explicit and detailed about the error that occurred. When parsing fails on all versions, we pick the parsing error from the newest syntax version and print the filename, line number, syntax version, piece of offending code, and the parsing error from LibCST:

```shell-session
(.venv) jreese@garbodor ~/workspace/usort parse-error± » cat foo.py
while i := foo():
    print("i"
(.venv) jreese@garbodor ~/workspace/usort parse-error± » usort format foo.py
Error sorting foo.py: Syntax Error @ 3:1.
Incomplete input. Encountered a dedent, but expected ')'.

    print("i"
             ^
```

Fixes #44 