### PR TITLE
Run CI on py3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
@@ -33,5 +33,6 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
+        if: ${{ matrix.python-version != '3.9' }}
       - name: Documentation
         run: make html

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Tim Hatch, Facebook
+Copyright (c) 2020 Facebook, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Facebook, Inc
+Copyright (c) 2020 Tim Hatch, Facebook
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This will also include a push of the skel branch, which is generated by the templates in https://github.com/thatch/fb-skel (that one's upstream is https://github.com/python-packaging/skel, but with the license portion changed)