### PR TITLE
Find configs outside of a given relative path.

### DIFF
--- a/usort/config.py
+++ b/usort/config.py
@@ -71,7 +71,7 @@ class Config:
         if filename is None:
             p = Path.cwd()
         else:
-            p = filename
+            p = Path.cwd() / filename
 
         while True:
             if p.is_dir():
@@ -96,7 +96,7 @@ class Config:
                 rv = rv.with_first_party(Path.cwd())
             else:
                 # filename, ideally
-                rv = rv.with_first_party(filename)
+                rv = rv.with_first_party(Path.cwd() / filename)
 
         return rv
 

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -19,8 +19,10 @@ from usort.cli import main
 def chdir(new_dir: str) -> Generator[None, None, None]:
     cur_dir = os.getcwd()
     os.chdir(new_dir)
-    yield
-    os.chdir(cur_dir)
+    try:
+        yield
+    finally:
+        os.chdir(cur_dir)
 
 
 @contextmanager


### PR DESCRIPTION
Need to be careful to not use Path.resolve() here which would follow the
symlink too early.

Fixes #43