### PR TITLE
Move imports before undecorated function and class definitions

### DIFF
--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -320,6 +320,116 @@ import c
 """
         self.assertEqual(content, usort_string(content, DEFAULT_CONFIG))
 
+    def test_function_without_decorator(self) -> None:
+        in_content = """\
+import a
+import b
+
+def function(arg: str) -> int:
+    return 0
+
+import c
+"""
+        out_content = """\
+import a
+import b
+import c
+
+def function(arg: str) -> int:
+    return 0
+"""
+        self.assertEqual(usort_string(in_content, DEFAULT_CONFIG), out_content)
+
+    def test_function_with_decorator(self) -> None:
+        content = """\
+import a
+import b
+
+@wrapped
+def function(arg: str) -> int:
+    return 0
+
+import c
+"""
+        self.assertEqual(usort_string(content, DEFAULT_CONFIG), content)
+
+    def test_class_without_decorator(self) -> None:
+        in_content = """\
+import a
+import b
+
+class SomeClass(Parent):
+    member: int
+
+import c
+"""
+        out_content = """\
+import a
+import b
+import c
+
+class SomeClass(Parent):
+    member: int
+"""
+        self.assertEqual(usort_string(in_content, DEFAULT_CONFIG), out_content)
+
+    def test_class_with_decorator(self) -> None:
+        content = """\
+import a
+import b
+
+@register
+class SomeClass(Parent):
+    member: int
+
+import c
+"""
+        self.assertEqual(usort_string(content, DEFAULT_CONFIG), content)
+
+    def test_nested_functions_and_classes(self) -> None:
+        in_content = """\
+import a
+import b
+
+class SomeClass(Parent):
+    member: int
+
+    import c
+    def function(self) -> int:
+        return 0
+    import d
+
+    @decorated
+    def function2(self) -> None:
+        import e
+        pass
+        import f
+    import g
+
+import h
+"""
+        out_content = """\
+import a
+import b
+import h
+
+class SomeClass(Parent):
+    member: int
+
+    import c
+    import d
+    def function(self) -> int:
+        return 0
+
+    @decorated
+    def function2(self) -> None:
+        import e
+        pass
+        import f
+    import g
+"""
+        self.assertEqual(usort_string(in_content, DEFAULT_CONFIG), out_content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When writing code in large files, I often place imports right above the code I'm actively editing. I'll then rely on code formatting to move imports as high as they can go, which often is the top of the file with the rest of the imports. (I do this to avoid having to move back and forth between the top and middle of the file.) This workflow was fine for isort, but usort is too conservative to move these imports, even though it is safe to do so. This PR enables that behavior by considering undecorated functions and class definitions as "safe" to move imports above, and doing so.

This was actually surprisingly straightforward, and although it required a small amount of refactoring, I think the PR's code speaks for itself, with one exception: it can now be the case that a `SortableBlock` contains no imports. I find this to not be a conceptually or nomenclaturally deceptive fact: the name "SortableBlock" does NOT imply anything about the nature of that block other than it be sortable. If you know how to make this clearer in the code, please let me know.

Similarly, please let me know if you'd like to see more unit tests; I added the first few that came to mind, but perhaps more would be warranted.