### PR TITLE
Switch source of truth for stdlibs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 LibCST>=0.3.6
-stdlib-list>=0.7.0
+stdlibs>=2021.4.1
 moreorless>=0.3.0
 toml>=0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ setup_requires =
 python_requires = >=3.6
 install_requires =
     LibCST >= 0.3.6
-    stdlib_list >= 0.7.0
     moreorless >= 0.3.0
+    stdlibs >= 2021.4.1
     toml >= 0.10.0
 
 [options.entry_points]

--- a/usort/config.py
+++ b/usort/config.py
@@ -27,6 +27,7 @@ def known_factory() -> Dict[str, Category]:
 
     # This is also in the stdlib list, so this override comes last...
     known["__future__"] = CAT_FUTURE
+    known["__main__"] = CAT_FIRST_PARTY
 
     return known
 

--- a/usort/stdlibs.py
+++ b/usort/stdlibs.py
@@ -3,10 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Set
+from typing import FrozenSet
 
-from stdlib_list.base import short_versions, stdlib_list
+from stdlibs import py27, py3
 
-STDLIB_MODULES: Set[str] = set(sum((stdlib_list(v) for v in short_versions), []))
-
-STDLIB_TOP_LEVEL_NAMES: Set[str] = set(v.split(".")[0] for v in STDLIB_MODULES)
+STDLIB_TOP_LEVEL_NAMES: FrozenSet[str] = py27.module_names | py3.module_names

--- a/usort/tests/__init__.py
+++ b/usort/tests/__init__.py
@@ -7,6 +7,7 @@ from .cli import CliTest
 from .config import ConfigTest
 from .functional import BasicOrderingTest, UsortStringFunctionalTest
 from .sort_key import IsSortableTest, SortableImportTest
+from .stdlibs import StdlibsTest
 
 __all__ = [
     "CliTest",
@@ -15,4 +16,5 @@ __all__ = [
     "UsortStringFunctionalTest",
     "IsSortableTest",
     "SortableImportTest",
+    "StdlibsTest",
 ]

--- a/usort/tests/stdlibs.py
+++ b/usort/tests/stdlibs.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from usort.stdlibs import STDLIB_TOP_LEVEL_NAMES
+
+
+class StdlibsTest(unittest.TestCase):
+    def test_expected(self) -> None:
+        # Py2 module
+        self.assertIn("StringIO", STDLIB_TOP_LEVEL_NAMES)
+
+        # This is specialcased, it appears to be a packaging decision for distros but I
+        # don't want to include it.
+        self.assertNotIn("test", STDLIB_TOP_LEVEL_NAMES)
+        self.assertNotIn("lib", STDLIB_TOP_LEVEL_NAMES)
+        self.assertNotIn("foo", STDLIB_TOP_LEVEL_NAMES)
+
+        self.assertIn("io", STDLIB_TOP_LEVEL_NAMES)
+        self.assertIn("os", STDLIB_TOP_LEVEL_NAMES)
+
+        # Py2 module
+        self.assertIn("sre", STDLIB_TOP_LEVEL_NAMES)
+        for name in ("re", "sre_parse", "_sre"):
+            self.assertIn(name, STDLIB_TOP_LEVEL_NAMES)


### PR DESCRIPTION
This should be a longer-term more reliable source of what top-level names come from stdlib.  It includes many more names (mostly C extensions) that were missing before; see https://github.com/jreese/stdlibs/pull/1 for some comparisons vs other possible sources.

While we're at it, take a stance on `__main__` being first-party code.  This seems to be most commonly used for subcommands in click, or for logging, but seems fragile and untestable to me.