### PR TITLE
Switch code formatting to ufmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,11 @@ test:
 
 .PHONY: format
 format:
-	python -m usort format $(SOURCES)
-	python -m black $(SOURCES)
+	python -m ufmt format $(SOURCES)
 
 .PHONY: lint
 lint:
-	python -m usort check $(SOURCES)
-	python -m black --check $(SOURCES)
+	python -m ufmt check $(SOURCES)
 	python -m flake8 $(SOURCES)
 	mypy --strict usort
 	/bin/bash check_copyright.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
-black==20.8b1
+black==21.4b0
+ufmt==1.2.1
 coverage==4.5.4
 flake8==3.8.4
 mypy==0.782


### PR DESCRIPTION
This will use the current checkout of usort for sorting if you use the
regular `make setup` target; if you set up your environment some other
way you'll need to use some care that it doesn't pull in just the public
deps of `ufmt`.