### PR TITLE
Refactor from_node into separate translate module

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 import libcst as cst
 
 from .config import Config
+from .translate import import_from_node
 from .types import SortableBlock, SortableImport
 
 
@@ -32,7 +33,7 @@ def sortable_blocks(
         # TODO support known_side_effect_modules or so
         if is_sortable_import(stmt, config):
             assert isinstance(stmt, cst.SimpleStatementLine)
-            imp = SortableImport.from_node(stmt, config)
+            imp = import_from_node(stmt, config)
             if cur is None:
                 cur = SortableBlock(i, i + 1)
                 ret.append(cur)

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -31,6 +31,7 @@ def sortable_blocks(
         # print(stmt)
         # TODO support known_side_effect_modules or so
         if is_sortable_import(stmt, config):
+            assert isinstance(stmt, cst.SimpleStatementLine)
             imp = SortableImport.from_node(stmt, config)
             if cur is None:
                 cur = SortableBlock(i, i + 1)

--- a/usort/tests/__init__.py
+++ b/usort/tests/__init__.py
@@ -6,8 +6,8 @@
 from .cli import CliTest
 from .config import ConfigTest
 from .functional import BasicOrderingTest, UsortStringFunctionalTest
-from .sort_key import IsSortableTest, SortableImportTest
 from .stdlibs import StdlibsTest
+from .translate import IsSortableTest, SortableImportTest
 from .util import UtilTest
 
 __all__ = [

--- a/usort/tests/__init__.py
+++ b/usort/tests/__init__.py
@@ -8,6 +8,7 @@ from .config import ConfigTest
 from .functional import BasicOrderingTest, UsortStringFunctionalTest
 from .sort_key import IsSortableTest, SortableImportTest
 from .stdlibs import StdlibsTest
+from .util import UtilTest
 
 __all__ = [
     "CliTest",
@@ -17,4 +18,5 @@ __all__ = [
     "IsSortableTest",
     "SortableImportTest",
     "StdlibsTest",
+    "UtilTest",
 ]

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -13,7 +13,7 @@ from typing import Optional
 from ..api import usort_string
 from ..config import Config
 from ..types import SortableImport
-from ..util import try_parse
+from ..util import parse_import
 
 DEFAULT_CONFIG = Config()
 
@@ -23,21 +23,19 @@ class BasicOrderingTest(unittest.TestCase):
 
     def test_order(self) -> None:
         items_in_order = [
-            b"from __future__ import division",
-            b"import os",
-            b"from os import path",
-            b"import tp",
-            b"from tp import x",
-            b"from .. import c",
-            b"from . import a",
-            b"from . import b",
-            b"from .a import z",
+            "from __future__ import division",
+            "import os",
+            "from os import path",
+            "import tp",
+            "from tp import x",
+            "from .. import c",
+            "from . import a",
+            "from . import b",
+            "from .a import z",
         ]
 
         nodes = [
-            SortableImport.from_node(
-                try_parse(Path("test.py"), data=x).body[0], config=DEFAULT_CONFIG
-            )
+            SortableImport.from_node(parse_import(x), config=DEFAULT_CONFIG)
             for x in items_in_order
         ]
         self.assertSequenceEqual(nodes, sorted(nodes))

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from ..api import usort_string
 from ..config import Config
-from ..types import SortableImport
+from ..translate import import_from_node
 from ..util import parse_import
 
 DEFAULT_CONFIG = Config()
@@ -35,7 +35,7 @@ class BasicOrderingTest(unittest.TestCase):
         ]
 
         nodes = [
-            SortableImport.from_node(parse_import(x), config=DEFAULT_CONFIG)
+            import_from_node(parse_import(x), config=DEFAULT_CONFIG)
             for x in items_in_order
         ]
         self.assertSequenceEqual(nodes, sorted(nodes))

--- a/usort/tests/sort_key.py
+++ b/usort/tests/sort_key.py
@@ -5,85 +5,72 @@
 
 import unittest
 
-import libcst as cst
-
 from ..config import Config
 from ..sorting import is_sortable_import
 from ..types import SortableImport
+from ..util import parse_import
 
 
 class SortableImportTest(unittest.TestCase):
     def test_from_node_Import(self) -> None:
-        imp = SortableImport.from_node(cst.parse_statement("import a"), Config())
+        imp = SortableImport.from_node(parse_import("import a"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(cst.parse_statement("import a, b"), Config())
+        imp = SortableImport.from_node(parse_import("import a, b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "a", "b": "b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(cst.parse_statement("import a as b"), Config())
+        imp = SortableImport.from_node(parse_import("import a as b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": "a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(cst.parse_statement("import os.path"), Config())
+        imp = SortableImport.from_node(parse_import("import os.path"), Config())
         self.assertEqual("os.path", imp.first_module)
         self.assertEqual("os.path", imp.first_dotted_import)
         self.assertEqual({"os": "os"}, imp.imported_names)
 
-        imp = SortableImport.from_node(
-            cst.parse_statement("import IPython.core"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("import IPython.core"), Config())
         self.assertEqual("IPython.core", imp.first_module)
         self.assertEqual("IPython.core", imp.first_dotted_import)
         self.assertEqual({"IPython": "IPython"}, imp.imported_names)
 
     def test_from_node_ImportFrom(self) -> None:
-        imp = SortableImport.from_node(cst.parse_statement("from a import b"), Config())
+        imp = SortableImport.from_node(parse_import("from a import b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("b", imp.first_dotted_import)
         self.assertEqual({"b": "a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(
-            cst.parse_statement("from a import b as c"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("from a import b as c"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("b", imp.first_dotted_import)
         self.assertEqual({"c": "a.b"}, imp.imported_names)
 
     def test_from_node_ImportFrom_relative(self) -> None:
-        imp = SortableImport.from_node(
-            cst.parse_statement("from .a import b"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("from .a import b"), Config())
         self.assertEqual(".a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": ".a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(
-            cst.parse_statement("from ...a import b"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("from ...a import b"), Config())
         self.assertEqual("...a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": "...a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(cst.parse_statement("from . import a"), Config())
+        imp = SortableImport.from_node(parse_import("from . import a"), Config())
         self.assertEqual(".", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": ".a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(
-            cst.parse_statement("from .. import a"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("from .. import a"), Config())
         self.assertEqual("..", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "..a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(
-            cst.parse_statement("from . import a as b"), Config()
-        )
+        imp = SortableImport.from_node(parse_import("from . import a as b"), Config())
         self.assertEqual(".", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": ".a"}, imp.imported_names)
@@ -91,10 +78,8 @@ class SortableImportTest(unittest.TestCase):
 
 class IsSortableTest(unittest.TestCase):
     def test_is_sortable(self) -> None:
-        self.assertTrue(is_sortable_import(cst.parse_statement("import a"), Config()))
-        self.assertTrue(
-            is_sortable_import(cst.parse_statement("from a import b"), Config())
-        )
+        self.assertTrue(is_sortable_import(parse_import("import a"), Config()))
+        self.assertTrue(is_sortable_import(parse_import("from a import b"), Config()))
         self.assertFalse(
-            is_sortable_import(cst.parse_statement("import a  # isort: skip"), Config())
+            is_sortable_import(parse_import("import a  # isort: skip"), Config())
         )

--- a/usort/tests/translate.py
+++ b/usort/tests/translate.py
@@ -7,70 +7,70 @@ import unittest
 
 from ..config import Config
 from ..sorting import is_sortable_import
-from ..types import SortableImport
+from ..translate import import_from_node
 from ..util import parse_import
 
 
 class SortableImportTest(unittest.TestCase):
     def test_from_node_Import(self) -> None:
-        imp = SortableImport.from_node(parse_import("import a"), Config())
+        imp = import_from_node(parse_import("import a"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("import a, b"), Config())
+        imp = import_from_node(parse_import("import a, b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "a", "b": "b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("import a as b"), Config())
+        imp = import_from_node(parse_import("import a as b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": "a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("import os.path"), Config())
+        imp = import_from_node(parse_import("import os.path"), Config())
         self.assertEqual("os.path", imp.first_module)
         self.assertEqual("os.path", imp.first_dotted_import)
         self.assertEqual({"os": "os"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("import IPython.core"), Config())
+        imp = import_from_node(parse_import("import IPython.core"), Config())
         self.assertEqual("IPython.core", imp.first_module)
         self.assertEqual("IPython.core", imp.first_dotted_import)
         self.assertEqual({"IPython": "IPython"}, imp.imported_names)
 
     def test_from_node_ImportFrom(self) -> None:
-        imp = SortableImport.from_node(parse_import("from a import b"), Config())
+        imp = import_from_node(parse_import("from a import b"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("b", imp.first_dotted_import)
         self.assertEqual({"b": "a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("from a import b as c"), Config())
+        imp = import_from_node(parse_import("from a import b as c"), Config())
         self.assertEqual("a", imp.first_module)
         self.assertEqual("b", imp.first_dotted_import)
         self.assertEqual({"c": "a.b"}, imp.imported_names)
 
     def test_from_node_ImportFrom_relative(self) -> None:
-        imp = SortableImport.from_node(parse_import("from .a import b"), Config())
+        imp = import_from_node(parse_import("from .a import b"), Config())
         self.assertEqual(".a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": ".a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("from ...a import b"), Config())
+        imp = import_from_node(parse_import("from ...a import b"), Config())
         self.assertEqual("...a", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": "...a.b"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("from . import a"), Config())
+        imp = import_from_node(parse_import("from . import a"), Config())
         self.assertEqual(".", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": ".a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("from .. import a"), Config())
+        imp = import_from_node(parse_import("from .. import a"), Config())
         self.assertEqual("..", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"a": "..a"}, imp.imported_names)
 
-        imp = SortableImport.from_node(parse_import("from . import a as b"), Config())
+        imp = import_from_node(parse_import("from . import a as b"), Config())
         self.assertEqual(".", imp.first_module)
         self.assertEqual("a", imp.first_dotted_import)
         self.assertEqual({"b": ".a"}, imp.imported_names)

--- a/usort/tests/util.py
+++ b/usort/tests/util.py
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import libcst as cst
+
+from ..util import parse_import
+
+
+class UtilTest(unittest.TestCase):
+    def test_parse_import_simple(self) -> None:
+        node = parse_import("import a")
+        self.assertIsInstance(node, cst.SimpleStatementLine)
+        self.assertIsInstance(node.body[0], cst.Import)
+        self.assertIsInstance(node.body[0].names[0], cst.ImportAlias)  # type: ignore
+        self.assertEqual(node.body[0].names[0].name.value, "a")  # type: ignore
+
+    def test_parse_import_from(self) -> None:
+        node = parse_import("from a import x")
+        self.assertIsInstance(node, cst.SimpleStatementLine)
+        self.assertIsInstance(node.body[0], cst.ImportFrom)
+        self.assertIsInstance(node.body[0].names[0], cst.ImportAlias)  # type: ignore
+        self.assertEqual(node.body[0].module.value, "a")  # type: ignore
+        self.assertEqual(node.body[0].names[0].name.value, "x")  # type: ignore
+
+    def test_parse_import_not_an_import(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not an import"):
+            parse_import("print('hello')")
+
+    def test_parse_import_not_a_statement(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not a statement"):
+            parse_import("for foo in bar: print(foo)")
+
+    def test_parse_import_bad_syntax(self) -> None:
+        with self.assertRaises(cst.ParserSyntaxError):
+            parse_import("say 'hello'")

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -1,0 +1,92 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Optional
+
+import libcst as cst
+
+from .config import Config
+from .types import SortableImport
+from .util import with_dots
+
+
+def import_from_node(node: cst.SimpleStatementLine, config: Config) -> SortableImport:
+    # TODO: This duplicates (differently) what's in the LibCST import
+    # metadata visitor.  This is also a bit hard to read.
+    first_module: Optional[str] = None
+    first_dotted_import: Optional[str] = None
+    names: Dict[str, str] = {}
+    sort_key: Optional[str] = None
+
+    # There are 4 basic types of import
+    # Additionally some forms z can have leading dots for relative
+    # imports, and there can be multiple on the right-hand side.
+    #
+    if isinstance(node.body[0], cst.Import):
+        # import z
+        # import z as y
+        for name in node.body[0].names:
+            if name.asname:
+                names[with_dots(name.asname.name).split(".")[0]] = with_dots(name.name)
+            else:
+                tmp = with_dots(name.name).split(".")[0]
+                names[tmp] = tmp
+
+            if first_module is None:
+                first_module = with_dots(name.name)
+                first_dotted_import = first_module
+
+    elif isinstance(node.body[0], cst.ImportFrom):
+        # from z import x
+        # from z import x as y
+
+        # This is treated as a barrier and should never get this far.
+        assert not isinstance(node.body[0].names, cst.ImportStar)
+
+        if node.body[0].module is None:
+            # from . import foo [as bar]
+            # (won't have dots but with_dots makes the typing easier)
+            sort_key = with_dots(node.body[0].names[0].name)
+            name_key = sort_key
+        else:
+            # from x import foo [as bar]
+            sort_key = with_dots(node.body[0].module)
+            name_key = sort_key + "."
+
+        if node.body[0].relative:
+            first_dotted_import = sort_key
+            sort_key = "." * len(node.body[0].relative)
+            if node.body[0].module is not None:
+                sort_key += first_dotted_import
+            name_key = sort_key
+            if node.body[0].module is not None:
+                name_key += "."
+
+        if first_module is None:
+            first_module = sort_key
+            if first_dotted_import is None:
+                for alias in node.body[0].names:
+                    first_dotted_import = with_dots(alias.name)
+                    break
+
+        for alias in node.body[0].names:
+            if alias.asname:
+                assert isinstance(alias.asname.name, cst.Name)
+                names[alias.asname.name.value] = name_key + with_dots(alias.name)
+            else:
+                assert isinstance(alias.name, cst.Name)
+                names[alias.name.value] = name_key + alias.name.value
+    else:
+        raise TypeError
+
+    assert first_module is not None
+    assert first_dotted_import is not None
+    return SortableImport(
+        node=node,
+        first_module=first_module,
+        first_dotted_import=first_dotted_import,
+        imported_names=names,
+        config=config,
+    )

--- a/usort/types.py
+++ b/usort/types.py
@@ -66,90 +66,88 @@ class SortableImport:
         )
 
     @classmethod
-    def from_node(cls, node: cst.CSTNode, config: Config) -> "SortableImport":
+    def from_node(
+        cls, node: cst.SimpleStatementLine, config: Config
+    ) -> "SortableImport":
         # TODO: This duplicates (differently) what's in the LibCST import
         # metadata visitor.  This is also a bit hard to read.
-        if isinstance(node, cst.SimpleStatementLine):
-            first_module: Optional[str] = None
-            first_dotted_import: Optional[str] = None
-            names: Dict[str, str] = {}
-            sort_key: Optional[str] = None
+        first_module: Optional[str] = None
+        first_dotted_import: Optional[str] = None
+        names: Dict[str, str] = {}
+        sort_key: Optional[str] = None
 
-            # There are 4 basic types of import
-            # Additionally some forms z can have leading dots for relative
-            # imports, and there can be multiple on the right-hand side.
-            #
-            if isinstance(node.body[0], cst.Import):
-                # import z
-                # import z as y
-                for name in node.body[0].names:
-                    if name.asname:
-                        names[with_dots(name.asname.name).split(".")[0]] = with_dots(
-                            name.name
-                        )
-                    else:
-                        tmp = with_dots(name.name).split(".")[0]
-                        names[tmp] = tmp
-
-                    if first_module is None:
-                        first_module = with_dots(name.name)
-                        first_dotted_import = first_module
-
-            elif isinstance(node.body[0], cst.ImportFrom):
-                # from z import x
-                # from z import x as y
-
-                # This is treated as a barrier and should never get this far.
-                assert not isinstance(node.body[0].names, cst.ImportStar)
-
-                if node.body[0].module is None:
-                    # from . import foo [as bar]
-                    # (won't have dots but with_dots makes the typing easier)
-                    sort_key = with_dots(node.body[0].names[0].name)
-                    name_key = sort_key
+        # There are 4 basic types of import
+        # Additionally some forms z can have leading dots for relative
+        # imports, and there can be multiple on the right-hand side.
+        #
+        if isinstance(node.body[0], cst.Import):
+            # import z
+            # import z as y
+            for name in node.body[0].names:
+                if name.asname:
+                    names[with_dots(name.asname.name).split(".")[0]] = with_dots(
+                        name.name
+                    )
                 else:
-                    # from x import foo [as bar]
-                    sort_key = with_dots(node.body[0].module)
-                    name_key = sort_key + "."
-
-                if node.body[0].relative:
-                    first_dotted_import = sort_key
-                    sort_key = "." * len(node.body[0].relative)
-                    if node.body[0].module is not None:
-                        sort_key += first_dotted_import
-                    name_key = sort_key
-                    if node.body[0].module is not None:
-                        name_key += "."
+                    tmp = with_dots(name.name).split(".")[0]
+                    names[tmp] = tmp
 
                 if first_module is None:
-                    first_module = sort_key
-                    if first_dotted_import is None:
-                        for alias in node.body[0].names:
-                            first_dotted_import = with_dots(alias.name)
-                            break
+                    first_module = with_dots(name.name)
+                    first_dotted_import = first_module
 
-                for alias in node.body[0].names:
-                    if alias.asname:
-                        assert isinstance(alias.asname.name, cst.Name)
-                        names[alias.asname.name.value] = name_key + with_dots(
-                            alias.name
-                        )
-                    else:
-                        assert isinstance(alias.name, cst.Name)
-                        names[alias.name.value] = name_key + alias.name.value
+        elif isinstance(node.body[0], cst.ImportFrom):
+            # from z import x
+            # from z import x as y
+
+            # This is treated as a barrier and should never get this far.
+            assert not isinstance(node.body[0].names, cst.ImportStar)
+
+            if node.body[0].module is None:
+                # from . import foo [as bar]
+                # (won't have dots but with_dots makes the typing easier)
+                sort_key = with_dots(node.body[0].names[0].name)
+                name_key = sort_key
             else:
-                raise TypeError
+                # from x import foo [as bar]
+                sort_key = with_dots(node.body[0].module)
+                name_key = sort_key + "."
 
-            assert first_module is not None
-            assert first_dotted_import is not None
-            return cls(
-                node=node,
-                first_module=first_module,
-                first_dotted_import=first_dotted_import,
-                imported_names=names,
-                config=config,
-            )
-        raise ValueError("Not an import")
+            if node.body[0].relative:
+                first_dotted_import = sort_key
+                sort_key = "." * len(node.body[0].relative)
+                if node.body[0].module is not None:
+                    sort_key += first_dotted_import
+                name_key = sort_key
+                if node.body[0].module is not None:
+                    name_key += "."
+
+            if first_module is None:
+                first_module = sort_key
+                if first_dotted_import is None:
+                    for alias in node.body[0].names:
+                        first_dotted_import = with_dots(alias.name)
+                        break
+
+            for alias in node.body[0].names:
+                if alias.asname:
+                    assert isinstance(alias.asname.name, cst.Name)
+                    names[alias.asname.name.value] = name_key + with_dots(alias.name)
+                else:
+                    assert isinstance(alias.name, cst.Name)
+                    names[alias.name.value] = name_key + alias.name.value
+        else:
+            raise TypeError
+
+        assert first_module is not None
+        assert first_dotted_import is not None
+        return cls(
+            node=node,
+            first_module=first_module,
+            first_dotted_import=first_dotted_import,
+            imported_names=names,
+            config=config,
+        )
 
 
 @dataclass

--- a/usort/types.py
+++ b/usort/types.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 import libcst as cst
 
 from .config import Config
-from .util import with_dots
 
 
 @dataclass
@@ -63,90 +62,6 @@ class SortableImport:
             is_from_import=isinstance(self.node.body[0], cst.ImportFrom),
             ndots=ndots,
             module=self.first_module.casefold(),
-        )
-
-    @classmethod
-    def from_node(
-        cls, node: cst.SimpleStatementLine, config: Config
-    ) -> "SortableImport":
-        # TODO: This duplicates (differently) what's in the LibCST import
-        # metadata visitor.  This is also a bit hard to read.
-        first_module: Optional[str] = None
-        first_dotted_import: Optional[str] = None
-        names: Dict[str, str] = {}
-        sort_key: Optional[str] = None
-
-        # There are 4 basic types of import
-        # Additionally some forms z can have leading dots for relative
-        # imports, and there can be multiple on the right-hand side.
-        #
-        if isinstance(node.body[0], cst.Import):
-            # import z
-            # import z as y
-            for name in node.body[0].names:
-                if name.asname:
-                    names[with_dots(name.asname.name).split(".")[0]] = with_dots(
-                        name.name
-                    )
-                else:
-                    tmp = with_dots(name.name).split(".")[0]
-                    names[tmp] = tmp
-
-                if first_module is None:
-                    first_module = with_dots(name.name)
-                    first_dotted_import = first_module
-
-        elif isinstance(node.body[0], cst.ImportFrom):
-            # from z import x
-            # from z import x as y
-
-            # This is treated as a barrier and should never get this far.
-            assert not isinstance(node.body[0].names, cst.ImportStar)
-
-            if node.body[0].module is None:
-                # from . import foo [as bar]
-                # (won't have dots but with_dots makes the typing easier)
-                sort_key = with_dots(node.body[0].names[0].name)
-                name_key = sort_key
-            else:
-                # from x import foo [as bar]
-                sort_key = with_dots(node.body[0].module)
-                name_key = sort_key + "."
-
-            if node.body[0].relative:
-                first_dotted_import = sort_key
-                sort_key = "." * len(node.body[0].relative)
-                if node.body[0].module is not None:
-                    sort_key += first_dotted_import
-                name_key = sort_key
-                if node.body[0].module is not None:
-                    name_key += "."
-
-            if first_module is None:
-                first_module = sort_key
-                if first_dotted_import is None:
-                    for alias in node.body[0].names:
-                        first_dotted_import = with_dots(alias.name)
-                        break
-
-            for alias in node.body[0].names:
-                if alias.asname:
-                    assert isinstance(alias.asname.name, cst.Name)
-                    names[alias.asname.name.value] = name_key + with_dots(alias.name)
-                else:
-                    assert isinstance(alias.name, cst.Name)
-                    names[alias.name.value] = name_key + alias.name.value
-        else:
-            raise TypeError
-
-        assert first_module is not None
-        assert first_dotted_import is not None
-        return cls(
-            node=node,
-            first_module=first_module,
-            first_dotted_import=first_dotted_import,
-            imported_names=names,
-            config=config,
         )
 
 

--- a/usort/util.py
+++ b/usort/util.py
@@ -77,6 +77,18 @@ def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:
         raise parse_error or Exception("unknown parse failure")
 
 
+def parse_import(code: str) -> cst.SimpleStatementLine:
+    """
+    Parse a single import statement. For testing and debugging purposes only.
+    """
+    node = cst.parse_statement(code)
+    if not isinstance(node, cst.SimpleStatementLine):
+        raise ValueError("not a statement")
+    if not isinstance(node.body[0], (cst.Import, cst.ImportFrom)):
+        raise ValueError("not an import statement")
+    return node
+
+
 def with_dots(x: cst.CSTNode) -> str:
     """
     Helper to make it easier to use an Attribute or Name.


### PR DESCRIPTION
* Adds `util.parse_import()` helper to parse statement and enforce type, with tests!
* Create a new `usort.translate` module.
* Move `types.SortableImport.from_node()` to `translate.import_from_node()`
* Rename `tests.sort_key` -> `tests.translate` to cover `import_from_node()`