### PR TITLE
Move type checks to "test" phase, lint on Py 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,5 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
-        if: ${{ matrix.python-version != '3.9' }}
       - name: Documentation
         run: make html

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ setup:
 test:
 	python -m coverage run -m usort.tests $(TESTOPTS)
 	python -m coverage report
+	python -m mypy --strict usort
 
 .PHONY: format
 format:
@@ -37,7 +38,6 @@ format:
 lint:
 	python -m ufmt check $(SOURCES)
 	python -m flake8 $(SOURCES)
-	mypy --strict usort
 	/bin/bash check_copyright.sh
 
 


### PR DESCRIPTION
Type checks are closer to tests than lints, so include them in `make test`. Linting works on Python 3.9 now, so let's actually lint on that runtime too.