### PR TITLE
Use trailrunner for walk and multiprocessing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ LibCST==0.3.21
 stdlibs==2021.4.1
 moreorless==0.4.0
 toml==0.10.2
+trailrunner==1.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     moreorless >= 0.3.0
     stdlibs >= 2021.4.1
     toml >= 0.10.0
+    trailrunner >= 1.0
 
 [options.entry_points]
 console_scripts =

--- a/usort/__init__.py
+++ b/usort/__init__.py
@@ -10,11 +10,12 @@ try:
 except ImportError:
     __version__ = "dev"
 
-from .api import usort_bytes, usort_path, usort_stdin, usort_string
+from .api import usort_bytes, usort_file, usort_path, usort_stdin, usort_string
 
 __all__ = [
     "__version__",
     "usort_bytes",
+    "usort_file",
     "usort_path",
     "usort_stdin",
     "usort_string",

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -7,6 +7,7 @@ import os
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
+from textwrap import dedent
 from typing import AnyStr, Generator
 
 import volatile
@@ -46,10 +47,14 @@ class CliTest(unittest.TestCase):
 
         self.assertRegex(
             result.output,
-            r"""walking \.:\s+\d+ µs
-parsing sample\.py:\s+\d+ µs
-sorting sample\.py:\s+\d+ µs
-""",
+            dedent(
+                r"""
+                parsing sample\.py:\s+\d+ µs
+                sorting sample\.py:\s+\d+ µs
+                walking \.:\s+\d+ µs
+                total for \.:\s+\d+ µs
+                """
+            ).strip(),
         )
         self.assertEqual(0, result.exit_code)
 

--- a/usort/types.py
+++ b/usort/types.py
@@ -5,22 +5,25 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import libcst as cst
 
 from .config import Config
+
+Timing = Tuple[str, float]
 
 
 @dataclass
 class Result:
     path: Path
     content: bytes
-    output: bytes
+    output: bytes = b""
     # encoding will be None on parse errors; we get this from LibCST on a successful
     # parse.
-    encoding: Optional[str]
+    encoding: Optional[str] = None
     error: Optional[Exception] = None
+    timings: Sequence[Timing] = ()
 
 
 @dataclass(order=True)


### PR DESCRIPTION
- Uses `trailrunner.walk()` to find paths to sort.
- Adds `usort_file()` function to sort a single file.
- Use `trailrunner.run()` in `usort_path()` to use child process for
  each file being sorted.
- Modify existing benchmark/timing APIs and usage to account for
  multiprocessing usage and return timings in the `Result` object.
- Update `cli` to use new timings API for printing benchmarks

Fixes #61 