### PR TITLE
Enable dependabot for weekly dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"


### PR DESCRIPTION
Enables weekly updates (every Tuesdays) of dependencies from dependabot. This will generate a PR for each dependency being updated, and automatically handles creating, rebasing, landing, and deleting branches. PR's can be closed to skip individual versions, and comments can be used to tell dependabot to do things like skipping future minor/major versions, landing when CI is green, etc.