### PR TITLE
Enable merging imports/comments using addition operators

### DIFF
--- a/usort/tests/types.py
+++ b/usort/tests/types.py
@@ -12,6 +12,208 @@ from .. import types
 class TypesTest(unittest.TestCase):
     maxDiff = None
 
+    def test_import_item_comments_add(self) -> None:
+        a = types.ImportItemComments(
+            before=["# hi"], inline=["# type: ignore"], following=[]
+        )
+        b = types.ImportItemComments(
+            before=[],
+            inline=["# noqa"],
+            following=["# bye"],
+        )
+        expected = types.ImportItemComments(
+            before=["# hi"],
+            inline=["# type: ignore", "# noqa"],
+            following=["# bye"],
+        )
+
+        with self.subTest("add"):
+            self.assertEqual(expected, a + b)
+
+        with self.subTest("inplace"):
+            a += b
+            self.assertEqual(expected, a)
+
+        with self.subTest("bad types"):
+            with self.assertRaisesRegex(
+                TypeError, "unsupported.+'ImportItemComments'.+'int'"
+            ):
+                a += 10  # type: ignore
+
+    def test_import_comments_add(self) -> None:
+        a = types.ImportComments(
+            before=["# header"],
+            first_inline=[],
+            initial=[],
+            inline=[],
+            final=[],
+            last_inline=["# footer"],
+        )
+        b = types.ImportComments(
+            before=[],
+            first_inline=["# noqa"],
+            initial=[],
+            inline=[],
+            final=[],
+            last_inline=["# goodbye"],
+        )
+        expected = types.ImportComments(
+            before=["# header"],
+            first_inline=["# noqa"],
+            initial=[],
+            inline=[],
+            final=[],
+            last_inline=["# footer", "# goodbye"],
+        )
+
+        with self.subTest("add"):
+            self.assertEqual(expected, a + b)
+
+        with self.subTest("inplace"):
+            a += b
+            self.assertEqual(expected, a)
+
+        with self.subTest("bad types"):
+            with self.assertRaisesRegex(
+                TypeError, "unsupported.+'ImportComments'.+'int'"
+            ):
+                a += 10  # type: ignore
+
+    def test_sortable_import_item_add(self) -> None:
+        a = types.SortableImportItem(
+            name="foo",
+            asname="foofoo",
+            comments=types.ImportItemComments(
+                inline=["# noqa"],
+            ),
+        )
+        b = types.SortableImportItem(
+            name="foo",
+            asname="foofoo",
+            comments=types.ImportItemComments(
+                before=["# hello"],
+            ),
+        )
+        expected = types.SortableImportItem(
+            name="foo",
+            asname="foofoo",
+            comments=types.ImportItemComments(
+                before=["# hello"],
+                inline=["# noqa"],
+            ),
+        )
+
+        with self.subTest("add"):
+            self.assertEqual(expected, a + b)
+
+        with self.subTest("inplace"):
+            a += b
+            self.assertEqual(expected, a)
+
+        with self.subTest("bad types"):
+            with self.assertRaisesRegex(
+                TypeError, "unsupported.+'SortableImportItem'.+'int'"
+            ):
+                a += 10  # type: ignore
+
+    def test_sortable_import_add(self) -> None:
+        a = types.SortableImport(
+            stem="foo",
+            items=[
+                types.SortableImportItem(
+                    name="bar",
+                    asname=None,
+                    comments=types.ImportItemComments(
+                        before=["# hello"],
+                    ),
+                ),
+                types.SortableImportItem(
+                    name="baz",
+                    asname=None,
+                    comments=types.ImportItemComments(
+                        inline=["# noqa"],
+                    ),
+                ),
+            ],
+            comments=types.ImportComments(
+                before=["# original block"],
+            ),
+            indent="",
+        )
+        b = types.SortableImport(
+            stem="foo",
+            items=[
+                types.SortableImportItem(
+                    name="bar",
+                    asname=None,
+                    comments=types.ImportItemComments(
+                        inline=["# noqa"],
+                    ),
+                ),
+                types.SortableImportItem(
+                    name="baz",
+                    asname="bazz",
+                    comments=types.ImportItemComments(),
+                ),
+                types.SortableImportItem(
+                    name="buzz",
+                    asname=None,
+                    comments=types.ImportItemComments(),
+                ),
+            ],
+            comments=types.ImportComments(
+                before=["# added block"],
+            ),
+            indent="",
+        )
+        expected = types.SortableImport(
+            stem="foo",
+            items=[
+                types.SortableImportItem(
+                    name="bar",
+                    asname=None,
+                    comments=types.ImportItemComments(
+                        before=["# hello"],
+                        inline=["# noqa"],
+                    ),
+                ),
+                types.SortableImportItem(
+                    name="baz",
+                    asname=None,
+                    comments=types.ImportItemComments(
+                        inline=["# noqa"],
+                    ),
+                ),
+                types.SortableImportItem(
+                    name="baz",
+                    asname="bazz",
+                    comments=types.ImportItemComments(),
+                ),
+                types.SortableImportItem(
+                    name="buzz",
+                    asname=None,
+                    comments=types.ImportItemComments(),
+                ),
+            ],
+            comments=types.ImportComments(
+                before=["# original block", "# added block"],
+            ),
+            indent="",
+        )
+
+        with self.subTest("add"):
+            self.assertEqual(expected, a + b)
+
+        with self.subTest("inplace"):
+            a += b
+            self.assertEqual(expected, a)
+
+        with self.subTest("bad types"):
+            with self.assertRaisesRegex(
+                TypeError, "unsupported.+'SortableImport'.+'int'"
+            ):
+                a += 10  # type: ignore
+
     def test_sortable_block_repr(self) -> None:
         imp = types.SortableBlock(
             start_idx=0,


### PR DESCRIPTION
This implements support in the types/data structures for merging import/item/comment values using the `+` and `+=` operators with other objects of the same types. Comments are just strictly appended/extended, while the list of items in a single import are merged in cases where both the `name` and `asname` match. Adds unit tests that validate the intermediate structure after merging, but does not implement logic to actually trigger these merges when sorting files.