### PR TITLE
Fix bug with import merging and multiple blocks

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -155,8 +155,7 @@ def sortable_blocks(
 
             current.add_import(imp, idx)
         else:
-            if current:
-                current = None
+            current = None
     return blocks
 
 
@@ -253,7 +252,9 @@ def find_and_sort_blocks(
         imports = fixup_whitespace(initial_blank, imports)
         block.imports = sorted(imports)
 
-    for block in blocks:
+    # replace statements in reverse order in case some got merged, which throws off
+    # indexes for statements past the merge
+    for block in reversed(blocks):
         sorted_body[block.start_idx : block.end_idx] = [
             import_to_node(imp, module, indent, config) for imp in block.imports
         ]

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -604,6 +604,30 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_merging_imports_with_multiple_blocks(self) -> None:
+        """verify that merging doesn't affect future blocks/statements"""
+        self.assertUsortResult(
+            """
+                import os
+                import os.path
+                from datetime import date
+                from datetime import datetime
+                from typing import *
+                import re
+                from pathlib import Path
+                print("hello world")
+            """,
+            """
+                import os
+                import os.path
+                from datetime import date, datetime
+                from typing import *
+                import re
+                from pathlib import Path
+                print("hello world")
+            """,
+        )
+
     def test_merging_import_items_comments(self) -> None:
         self.assertUsortResult(
             """


### PR DESCRIPTION
This fixes a bug introduced by import merging, when there is at least one block *after* the block that includes a merge. The bug resulted in a duplicate import, and removal of whatever statement followed the next block, because indexes get thrown off by the merge when replacing elements in the CST.

Repro:

```python
from datetime import date
from datetime import datetime
import os  # usort:skip
import re
print("hello world")
```

µsort would generate the following diff:
```diff
--- a/f.py
+++ b/f.py
@@ -1,5 +1,4 @@
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 import os  # usort:skip
 import re
-print("hello world")
+import re
```

This fixes the bug and adds a new test case (that fails on 1.0.0a1).