### PR TITLE
Fix CSTValidationError on basic imports with long inline comments

### DIFF
--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -542,6 +542,19 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_single_line_import_long_comment(self) -> None:
+        """
+        Basic import statements can't be reflowed to multiple lines
+        """
+        self.assertUsortResult(
+            """
+                import foo, bar, baz  # some really long inline comment that would can't be reflowed to a new line
+            """,
+            """
+                import bar, baz, foo  # some really long inline comment that would can't be reflowed to a new line
+            """,
+        )
+
     def test_sorting_import_items(self) -> None:
         self.assertUsortResult(
             """

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -222,7 +222,8 @@ def import_to_node(
 ) -> cst.BaseStatement:
     node = import_to_node_single(imp, module)
     content = indent + render_node(node, module).rstrip()
-    if len(content) > config.line_length:
+    # basic imports can't be reflowed, so only deal with from-imports
+    if imp.stem and len(content) > config.line_length:
         node = import_to_node_multi(imp, module)
     return node
 
@@ -385,7 +386,7 @@ def import_to_node_multi(imp: SortableImport, module: cst.Module) -> cst.BaseSta
 
     # import foo
     else:
-        body = [cst.Import(names=names)]
+        raise ValueError("can't render basic imports on multiple lines")
 
     # comment lines above import
     leading_lines = [


### PR DESCRIPTION
Basic imports can't be reflowed to multiple lines, which results in a LibCST validation error when usort attempts to reflow basic imports with long inline comments.

```shell-session
(.venv) jreese@butterfree ~/workspace/usort main± » cat f.py
import foo, bar, baz  # some really long inline comment that would can't be reflowed to a new line
(.venv) jreese@butterfree ~/workspace/usort main± » usort diff f.py
Error sorting f.py: An ImportStatement does not allow a trailing comma
```

This fixes the `import_to_node()` logic to skip multiline rendering for basic imports, and updates `import_to_node_multi()` to raise a ValueError if it receives a basic import. This also adds a test case (that fails on current main) to cover this behavior.