### PR TITLE
Pass sorting warnings up through API and output via CLI

### DIFF
--- a/usort/cli.py
+++ b/usort/cli.py
@@ -17,7 +17,7 @@ from usort.translate import render_node
 from . import __version__
 from .api import usort_path, usort_stdin
 from .config import Config
-from .sorting import sortable_blocks
+from .sorting import ImportSorter
 from .types import Options
 from .util import get_timings, print_timings, Timing, try_parse
 
@@ -75,7 +75,8 @@ def list_imports(multiples: bool, debug: bool, filenames: List[str]) -> int:
         config = Config.find(Path(f))
         mod = try_parse(Path(f))
         try:
-            blocks = sortable_blocks(mod.body, config)
+            sorter = ImportSorter(module=mod, config=config)
+            blocks = sorter.sortable_blocks(mod.body)
         except Exception as e:
             print("Exception", f, e)
             continue

--- a/usort/cli.py
+++ b/usort/cli.py
@@ -72,10 +72,11 @@ def list_imports(multiples: bool, debug: bool, filenames: List[str]) -> int:
     # where the barriers are that produce different blocks.
 
     for f in filenames:
-        config = Config.find(Path(f))
-        mod = try_parse(Path(f))
+        path = Path(f)
+        config = Config.find(path)
+        mod = try_parse(path)
         try:
-            sorter = ImportSorter(module=mod, config=config)
+            sorter = ImportSorter(module=mod, path=path, config=config)
             blocks = sorter.sortable_blocks(mod.body)
         except Exception as e:
             print("Exception", f, e)
@@ -123,6 +124,9 @@ def check(filenames: List[str]) -> int:
                 click.echo(f"Error sorting {result.path}: {result.error}")
                 return_code |= 1
 
+            for warning in result.warnings:
+                click.echo(f"Warning at {result.path}:{warning.line} {warning.message}")
+
             if result.content != result.output:
                 click.echo(f"Would sort {result.path}")
                 return_code |= 2
@@ -153,6 +157,9 @@ def diff(ctx: click.Context, filenames: List[str]) -> int:
                     click.echo(result.trace)
                 return_code |= 1
                 continue
+
+            for warning in result.warnings:
+                click.echo(f"Warning at {result.path}:{warning.line} {warning.message}")
 
             if result.content != result.output:
                 assert result.encoding is not None
@@ -193,6 +200,9 @@ def format(filenames: List[str]) -> int:
                 click.echo(f"Error sorting {result.path}: {result.error}")
                 return_code |= 1
                 continue
+
+            for warning in result.warnings:
+                click.echo(f"Warning at {result.path}:{warning.line} {warning.message}")
 
             if result.content != result.output:
                 click.echo(f"Sorted {result.path}")

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -11,263 +11,280 @@ from libcst.metadata import PositionProvider
 
 from .config import Config
 from .translate import import_from_node, import_to_node
-from .types import SortableBlock, SortableImport
+from .types import SortableBlock, SortableImport, SortWarning
 
 LOG = logging.getLogger(__name__)
 
 
-def is_sortable_import(stmt: cst.CSTNode, config: Config) -> bool:
-    """
-    Determine if any individual statement is sortable or should be a barrier.
+class ImportSorter:
+    def __init__(self, *, module: cst.Module, config: Config):
+        self.config = config
+        self.module = module
+        self.warnings: List[SortWarning] = []
+        self.wrapper = cst.MetadataWrapper(module)
+        self.transformer = ImportSortingTransformer(config, module, self)
 
-    Handles skip directives, configured side effect modules, and star imports.
-    """
-    if isinstance(stmt, cst.SimpleStatementLine):
-        com = stmt.trailing_whitespace.comment
-        if com:
-            com_str = com.value.replace(" ", "")
-            if com_str.startswith("#usort:skip") or com_str.startswith("#isort:skip"):
-                return False
+    def is_sortable_import(self, stmt: cst.CSTNode) -> bool:
+        """
+        Determine if any individual statement is sortable or should be a barrier.
 
-        # N.b. `body` is a list, because the SimpleStatementLine might have
-        # semicolons.  We only look at the first, which is probably the most
-        # dangerous thing in here.
-        #
-        # If black is run, it will put the semicolon pieces on different lines,
-        # but we don't want to do that until we reflow and handle directives
-        # like noqa.  TODO do that before calling is_sortable_import, and assert
-        # that it's not a compound statement line.
-        if isinstance(stmt.body[0], cst.ImportFrom):
-            # `from x import *` is a barrier
-            if isinstance(stmt.body[0].names, cst.ImportStar):
-                return False
-            # check for side effect modules, but ignore local (from .) imports (TODO?)
-            elif stmt.body[0].module is not None:
-                base = cst.helpers.get_full_name_for_node_or_raise(stmt.body[0].module)
-                names = [name.evaluated_name for name in stmt.body[0].names]
-                if config.is_side_effect_import(base, names):
+        Handles skip directives, configured side effect modules, and star imports.
+        """
+        if isinstance(stmt, cst.SimpleStatementLine):
+            com = stmt.trailing_whitespace.comment
+            if com:
+                com_str = com.value.replace(" ", "")
+                if com_str.startswith("#usort:skip") or com_str.startswith(
+                    "#isort:skip"
+                ):
                     return False
-            return True
-        elif isinstance(stmt.body[0], cst.Import):
-            base = ""
-            names = [name.evaluated_name for name in stmt.body[0].names]
-            if config.is_side_effect_import(base, names):
+
+            # N.b. `body` is a list, because the SimpleStatementLine might have
+            # semicolons.  We only look at the first, which is probably the most
+            # dangerous thing in here.
+            #
+            # If black is run, it will put the semicolon pieces on different lines,
+            # but we don't want to do that until we reflow and handle directives
+            # like noqa.  TODO do that before calling is_sortable_import, and assert
+            # that it's not a compound statement line.
+            if isinstance(stmt.body[0], cst.ImportFrom):
+                # `from x import *` is a barrier
+                if isinstance(stmt.body[0].names, cst.ImportStar):
+                    return False
+                # check for side effect modules, but ignore local (from .) imports (TODO?)
+                elif stmt.body[0].module is not None:
+                    base = cst.helpers.get_full_name_for_node_or_raise(
+                        stmt.body[0].module
+                    )
+                    names = [name.evaluated_name for name in stmt.body[0].names]
+                    if self.config.is_side_effect_import(base, names):
+                        return False
+                return True
+            elif isinstance(stmt.body[0], cst.Import):
+                base = ""
+                names = [name.evaluated_name for name in stmt.body[0].names]
+                if self.config.is_side_effect_import(base, names):
+                    return False
+                return True
+            else:
                 return False
-            return True
         else:
             return False
-    else:
-        return False
 
+    def name_overlap(self, block: SortableBlock, imp: SortableImport) -> Set[str]:
+        """
+        Find imported names that overlap existing names for a block of imports.
 
-def name_overlap(block: SortableBlock, imp: SortableImport) -> Set[str]:
-    """
-    Find imported names that overlap existing names for a block of imports.
+        Compares imports of a proposed, but not yet included, import with existing imports
+        in a block. Ignores multiple imports of the same "name" that come from the same
+        qualified name. Eg, `os.path` doesn't shadow `os`, but `from foo import os` does.
 
-    Compares imports of a proposed, but not yet included, import with existing imports
-    in a block. Ignores multiple imports of the same "name" that come from the same
-    qualified name. Eg, `os.path` doesn't shadow `os`, but `from foo import os` does.
+        Returns a set of qualified names from `imp` that shadow names from `block`.
+        This set will be empty if there are no overlaps.
+        """
+        overlap: Set[str] = set()
 
-    Returns a set of qualified names from `imp` that shadow names from `block`.
-    This set will be empty if there are no overlaps.
-    """
-    overlap: Set[str] = set()
+        for key, value in imp.imported_names.items():
+            shadowed = block.imported_names.get(key)
+            if shadowed and shadowed != value:
+                LOG.warning(
+                    f"Name {shadowed!r} shadowed by {value!r}; implicit block split"
+                )
+                overlap.add(shadowed)
 
-    for key, value in imp.imported_names.items():
-        shadowed = block.imported_names.get(key)
-        if shadowed and shadowed != value:
-            LOG.warning(
-                f"Name {shadowed!r} shadowed by {value!r}; implicit block split"
-            )
-            overlap.add(shadowed)
+        return overlap
 
-    return overlap
+    def split_inplace(self, block: SortableBlock, overlap: Set[str]) -> SortableBlock:
+        """
+        Split an existing block into two blocks after the last shadowed import.
 
+        Pre-sorts the block of imports, then finds the last import with shadowed names, and
+        splits after that import. Returns a new block containing all imports after the split
+        point, or empty otherwise.
+        """
+        # best-effort pre-sorting before we split
+        for imp in block.imports:
+            imp.items.sort()
+        block.imports.sort()
 
-def split_inplace(block: SortableBlock, overlap: Set[str]) -> SortableBlock:
-    """
-    Split an existing block into two blocks after the last shadowed import.
+        # find index of last shadowed import, starting from the end of the block's imports
+        idx = len(block.imports)
+        while idx > 0:
+            idx -= 1
+            imp = block.imports[idx]
+            if any(item.fullname in overlap for item in imp.items):
+                break
 
-    Pre-sorts the block of imports, then finds the last import with shadowed names, and
-    splits after that import. Returns a new block containing all imports after the split
-    point, or empty otherwise.
-    """
-    # best-effort pre-sorting before we split
-    for imp in block.imports:
-        imp.items.sort()
-    block.imports.sort()
+        count = idx + 1
+        if count >= len(block.imports):
+            # shadowed import is the last import in the block, so we can't split anything.
+            # return a new, empty block following pattern from sortable_blocks()
+            new = SortableBlock(block.end_idx, block.end_idx + 1)
 
-    # find index of last shadowed import, starting from the end of the block's imports
-    idx = len(block.imports)
-    while idx > 0:
-        idx -= 1
-        imp = block.imports[idx]
-        if any(item.fullname in overlap for item in imp.items):
-            break
-
-    count = idx + 1
-    if count >= len(block.imports):
-        # shadowed import is the last import in the block, so we can't split anything.
-        # return a new, empty block following pattern from sortable_blocks()
-        new = SortableBlock(block.end_idx, block.end_idx + 1)
-
-    else:
-        # Split the existing block after the shadowed import, creating a new block that
-        # starts after the shadowed import, update the old block's end index, and then
-        # move all the imports after that to the new block
-        new = SortableBlock(block.start_idx + count, block.end_idx)
-        block.end_idx = block.start_idx + count
-
-        new.imports = block.imports[count:]
-        block.imports[count:] = []
-
-        # move imported names metadata
-        for imp in new.imports:
-            for key in list(imp.imported_names):
-                new.imported_names[key] = block.imported_names.pop(key)
-
-    return new
-
-
-def sortable_blocks(
-    body: Sequence[cst.BaseStatement], config: Config
-) -> List[SortableBlock]:
-    """
-    Finds blocks of imports separated by barriers (non-import statements, or
-    dangerous imports).  We will only sort within a block, and only when there
-    are no duplicate names.
-    """
-    blocks: List[SortableBlock] = []
-    current: Optional[SortableBlock] = None
-    for idx, stmt in enumerate(body):
-        if is_sortable_import(stmt, config):
-            assert isinstance(stmt, cst.SimpleStatementLine)
-            imp = import_from_node(stmt, config)
-            if current is None:
-                current = SortableBlock(idx, idx + 1)
-                blocks.append(current)
-
-            overlap = name_overlap(current, imp)
-            if overlap:
-                # This overwrites an earlier name
-                current = split_inplace(current, overlap)
-                blocks.append(current)
-
-            current.add_import(imp, idx)
         else:
-            current = None
-    return blocks
+            # Split the existing block after the shadowed import, creating a new block that
+            # starts after the shadowed import, update the old block's end index, and then
+            # move all the imports after that to the new block
+            new = SortableBlock(block.start_idx + count, block.end_idx)
+            block.end_idx = block.start_idx + count
 
+            new.imports = block.imports[count:]
+            block.imports[count:] = []
 
-def partition_leading_lines(
-    lines: List[str],
-) -> Tuple[List[str], List[str]]:
-    """
-    Returns a tuple of the initial blank lines, and the comment lines.
-    """
-    for j in range(len(lines)):
-        if lines[j].startswith("#"):
-            break
-    else:
-        j = len(lines)
+            # move imported names metadata
+            for imp in new.imports:
+                for key in list(imp.imported_names):
+                    new.imported_names[key] = block.imported_names.pop(key)
 
-    return lines[:j], lines[j:]
+        return new
 
+    def sortable_blocks(self, body: Sequence[cst.BaseStatement]) -> List[SortableBlock]:
+        """
+        Finds blocks of imports separated by barriers (non-import statements, or
+        dangerous imports).  We will only sort within a block, and only when there
+        are no duplicate names.
+        """
+        blocks: List[SortableBlock] = []
+        current: Optional[SortableBlock] = None
+        for idx, stmt in enumerate(body):
+            if self.is_sortable_import(stmt):
+                assert isinstance(stmt, cst.SimpleStatementLine)
+                imp = import_from_node(stmt, self.config)
+                if current is None:
+                    current = SortableBlock(idx, idx + 1)
+                    blocks.append(current)
 
-def fixup_whitespace(
-    initial_blank: Sequence[str], imports: List[SortableImport]
-) -> List[SortableImport]:
-    """
-    Normalize whitespace/comments on a block of imports before transforming back to CST.
-    """
-    cur_category = None
-    # TODO if they've already been reshuffled, there may have been a blank
-    # (separator) line between a non-block and the first import, that's now in
-    # the middle.
-    for imp in imports:
-        _old_blanks, old_comments = partition_leading_lines(imp.comments.before)
+                overlap = self.name_overlap(current, imp)
+                if overlap:
+                    # This overwrites an earlier name
+                    current = self.split_inplace(current, overlap)
+                    blocks.append(current)
 
-        if cur_category is None:
-            blanks = initial_blank
-        elif imp.sort_key.category_index != cur_category:
-            blanks = ("",)
-        else:
-            blanks = _old_blanks[:1]
-
-        imp.comments.before = [*blanks, *old_comments]
-
-        cur_category = imp.sort_key.category_index
-    return imports
-
-
-def merge_and_sort_imports(
-    imports: List[SortableImport], config: Config
-) -> List[SortableImport]:
-    if config.merge_imports:
-        # Look for sequential imports with matching stems, and merge them.
-        idx = 0
-        while idx + 1 < len(imports):
-            imp = imports[idx]
-            nxt = imports[idx + 1]
-
-            if (
-                # This is a from-import and the next statement is from the same module
-                (imp.stem and imp.stem == nxt.stem)
-                # This is a module-import and the next statement imports the same module
-                or (imp.stem is None and imp.items == nxt.items)
-            ):
-                # Merge them and discard the second import from the list.
-                imports[idx] += nxt
-                imports.pop(idx + 1)
-
+                current.add_import(imp, idx)
             else:
-                idx += 1
+                current = None
+        return blocks
 
-    # Sort items within each remaining statement
-    for imp in imports:
-        imp.items.sort()
+    def partition_leading_lines(
+        self,
+        lines: List[str],
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Returns a tuple of the initial blank lines, and the comment lines.
+        """
+        for j in range(len(lines)):
+            if lines[j].startswith("#"):
+                break
+        else:
+            j = len(lines)
 
-    return imports
+        return lines[:j], lines[j:]
 
+    def fixup_whitespace(
+        self, initial_blank: Sequence[str], imports: List[SortableImport]
+    ) -> List[SortableImport]:
+        """
+        Normalize whitespace/comments on a block of imports before transforming back to CST.
+        """
+        cur_category = None
+        # TODO if they've already been reshuffled, there may have been a blank
+        # (separator) line between a non-block and the first import, that's now in
+        # the middle.
+        for imp in imports:
+            _old_blanks, old_comments = self.partition_leading_lines(
+                imp.comments.before
+            )
 
-def find_and_sort_blocks(
-    body: Sequence[cst.BaseStatement], module: cst.Module, indent: str, config: Config
-) -> Sequence[cst.BaseStatement]:
-    """
-    Find all sortable blocks in a module, sort them, and return updated module content.
-    """
-    sorted_body: List[cst.BaseStatement] = list(body)
-    blocks = list(sortable_blocks(body, config=config))
+            if cur_category is None:
+                blanks = initial_blank
+            elif imp.sort_key.category_index != cur_category:
+                blanks = ("",)
+            else:
+                blanks = _old_blanks[:1]
 
-    for block in blocks:
-        initial_blank, initial_comment = partition_leading_lines(
-            block.imports[0].comments.before
-        )
-        block.imports[0].comments.before = initial_comment
-        # Sort the imports first, so that imports from the same module line up, then
-        # merge and sort imports/items, then re-sort the final set of imports again
-        # in case unsorted items affected overall sorting.
-        imports = sorted(block.imports)
-        imports = merge_and_sort_imports(imports, config)
-        imports = fixup_whitespace(initial_blank, imports)
-        block.imports = sorted(imports)
+            imp.comments.before = [*blanks, *old_comments]
 
-    # replace statements in reverse order in case some got merged, which throws off
-    # indexes for statements past the merge
-    for block in reversed(blocks):
-        sorted_body[block.start_idx : block.end_idx] = [
-            import_to_node(imp, module, indent, config) for imp in block.imports
-        ]
+            cur_category = imp.sort_key.category_index
+        return imports
 
-    return sorted_body
+    def merge_and_sort_imports(
+        self, imports: List[SortableImport]
+    ) -> List[SortableImport]:
+        if self.config.merge_imports:
+            # Look for sequential imports with matching stems, and merge them.
+            idx = 0
+            while idx + 1 < len(imports):
+                imp = imports[idx]
+                nxt = imports[idx + 1]
+
+                if (
+                    # This is a from-import and the next statement is from the same module
+                    (imp.stem and imp.stem == nxt.stem)
+                    # This is a module-import and the next statement imports the same module
+                    or (imp.stem is None and imp.items == nxt.items)
+                ):
+                    # Merge them and discard the second import from the list.
+                    imports[idx] += nxt
+                    imports.pop(idx + 1)
+
+                else:
+                    idx += 1
+
+        # Sort items within each remaining statement
+        for imp in imports:
+            imp.items.sort()
+
+        return imports
+
+    def find_and_sort_blocks(
+        self,
+        body: Sequence[cst.BaseStatement],
+        module: cst.Module,
+        indent: str,
+    ) -> Sequence[cst.BaseStatement]:
+        """
+        Find all sortable blocks in a module, sort them, and return updated module content.
+        """
+        sorted_body: List[cst.BaseStatement] = list(body)
+        blocks = list(self.sortable_blocks(body))
+
+        for block in blocks:
+            initial_blank, initial_comment = self.partition_leading_lines(
+                block.imports[0].comments.before
+            )
+            block.imports[0].comments.before = initial_comment
+            # Sort the imports first, so that imports from the same module line up, then
+            # merge and sort imports/items, then re-sort the final set of imports again
+            # in case unsorted items affected overall sorting.
+            imports = sorted(block.imports)
+            imports = self.merge_and_sort_imports(imports)
+            imports = self.fixup_whitespace(initial_blank, imports)
+            block.imports = sorted(imports)
+
+        # replace statements in reverse order in case some got merged, which throws off
+        # indexes for statements past the merge
+        for block in reversed(blocks):
+            sorted_body[block.start_idx : block.end_idx] = [
+                import_to_node(imp, module, indent, self.config)
+                for imp in block.imports
+            ]
+
+        return sorted_body
+
+    def sort_module(self) -> cst.Module:
+        new_module = self.wrapper.visit(self.transformer)
+        return new_module
 
 
 class ImportSortingTransformer(cst.CSTTransformer):
     METADATA_DEPENDENCIES = (PositionProvider,)
 
-    def __init__(self, config: Config, module: cst.Module) -> None:
+    def __init__(
+        self, config: Config, module: cst.Module, sorter: ImportSorter
+    ) -> None:
         self.config = config
         self.module = module
+        self.sorter = sorter
 
     def get_indent(self, node: cst.CSTNode) -> str:
         pos = self.get_metadata(PositionProvider, node)
@@ -279,8 +296,8 @@ class ImportSortingTransformer(cst.CSTTransformer):
         self, original_node: cst.Module, updated_node: cst.Module
     ) -> cst.Module:
         indent = self.get_indent(original_node)
-        sorted_body = find_and_sort_blocks(
-            updated_node.body, module=self.module, indent=indent, config=self.config
+        sorted_body = self.sorter.find_and_sort_blocks(
+            updated_node.body, module=self.module, indent=indent
         )
         return updated_node.with_changes(body=sorted_body)
 
@@ -288,14 +305,11 @@ class ImportSortingTransformer(cst.CSTTransformer):
         self, original_node: cst.IndentedBlock, updated_node: cst.IndentedBlock
     ) -> cst.BaseSuite:
         indent = self.get_indent(original_node)
-        sorted_body = find_and_sort_blocks(
-            updated_node.body, module=self.module, indent=indent, config=self.config
+        sorted_body = self.sorter.find_and_sort_blocks(
+            updated_node.body, module=self.module, indent=indent
         )
         return updated_node.with_changes(body=sorted_body)
 
 
 def sort_module(module: cst.Module, config: Config) -> cst.Module:
-    wrapper = cst.MetadataWrapper(module)
-    transform = ImportSortingTransformer(config, module)
-    new_module = wrapper.visit(transform)
-    return new_module
+    return ImportSorter(module=module, config=config).sort_module()

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -102,6 +102,18 @@ class CliTest(unittest.TestCase):
         self.assertEqual("Would sort sample.py\n", result.output)
         self.assertEqual(2, result.exit_code)
 
+    def test_check_with_warnings(self) -> None:
+        with sample_contents(b"import os\nimport sys\nimport re as os\n") as dtmp:
+            runner = CliRunner()
+            with chdir(dtmp):
+                result = runner.invoke(main, ["check", "."])
+
+        self.assertEqual(
+            "Warning at sample.py:3 Name 'os' shadowed by 're'; implicit block split\n"
+            "Would sort sample.py\n",
+            result.output,
+        )
+
     def test_diff_no_change(self) -> None:
         with sample_contents("import sys\n") as dtmp:
             runner = CliRunner()

--- a/usort/tests/translate.py
+++ b/usort/tests/translate.py
@@ -5,8 +5,10 @@
 
 import unittest
 
+import libcst as cst
+
 from ..config import Config
-from ..sorting import is_sortable_import
+from ..sorting import ImportSorter
 from ..translate import import_from_node
 from ..util import parse_import
 
@@ -81,8 +83,9 @@ class SortableImportTest(unittest.TestCase):
 
 class IsSortableTest(unittest.TestCase):
     def test_is_sortable(self) -> None:
-        self.assertTrue(is_sortable_import(parse_import("import a"), Config()))
-        self.assertTrue(is_sortable_import(parse_import("from a import b"), Config()))
+        sorter = ImportSorter(module=cst.Module([]), config=Config())
+        self.assertTrue(sorter.is_sortable_import(parse_import("import a")))
+        self.assertTrue(sorter.is_sortable_import(parse_import("from a import b")))
         self.assertFalse(
-            is_sortable_import(parse_import("import a  # isort: skip"), Config())
+            sorter.is_sortable_import(parse_import("import a  # isort: skip"))
         )

--- a/usort/tests/translate.py
+++ b/usort/tests/translate.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from pathlib import Path
 
 import libcst as cst
 
@@ -83,7 +84,7 @@ class SortableImportTest(unittest.TestCase):
 
 class IsSortableTest(unittest.TestCase):
     def test_is_sortable(self) -> None:
-        sorter = ImportSorter(module=cst.Module([]), config=Config())
+        sorter = ImportSorter(module=cst.Module([]), path=Path(), config=Config())
         self.assertTrue(sorter.is_sortable_import(parse_import("import a")))
         self.assertTrue(sorter.is_sortable_import(parse_import("from a import b")))
         self.assertFalse(

--- a/usort/types.py
+++ b/usort/types.py
@@ -28,6 +28,12 @@ class Options:
 
 
 @dataclass
+class SortWarning:
+    line: int
+    message: str
+
+
+@dataclass
 class Result:
     path: Path
     content: bytes
@@ -38,6 +44,7 @@ class Result:
     error: Optional[Exception] = None
     trace: str = ""
     timings: Sequence[Timing] = ()
+    warnings: Sequence[SortWarning] = ()
 
 
 @dataclass

--- a/usort/types.py
+++ b/usort/types.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+import traceback
 from pathlib import Path
 from textwrap import dedent, indent
 from typing import Dict, List, Optional, Sequence
@@ -36,7 +38,7 @@ class SortWarning:
 @dataclass
 class Result:
     path: Path
-    content: bytes
+    content: bytes = b""
     output: bytes = b""
     # encoding will be None on parse errors; we get this from LibCST on a successful
     # parse.
@@ -45,6 +47,12 @@ class Result:
     trace: str = ""
     timings: Sequence[Timing] = ()
     warnings: Sequence[SortWarning] = ()
+
+    def __attrs_post_init__(self) -> None:
+        if self.error:
+            exc_type, exc, tb = sys.exc_info()
+            if exc_type is not None:
+                self.trace = "".join(traceback.format_exception(exc_type, exc, tb))
 
 
 @dataclass


### PR DESCRIPTION
Rather than simply printing warnings to stdout/stderr while in the middle of sorting a file, this refactors µsort to use a class-based sorter implementation, which tracks any warnings encountered while sorting, and includes those warnings in the Result object generated in the API. These warnings are then handled by the CLI and output to stdout alongside the appropriate diff/status output.

Notes:

* This changes the API of `usort_bytes` to return a `Result` object directly, rather than `(new_bytes, encoding)`. As we are still pre-1.0, I'm considering this the best time to make this change, and will update µfmt to handle this correctly.