### PR TITLE
Document public API, improve merging docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0a2
+
+Alpha release
+
+* Deprecation: `usort_bytes()` and `usort_string()` replaced by `usort()` (#88)
+* Fixed bug when merging imports and subsequent blocks (#86)
+* Fixed output of basic imports that exceed line length (#87)
+
 ## 1.0.0a1
 
 Alpha release

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ lexicographically within each group. This will commonly look like:
 import re
 from pathlib import Path
 from typing import Iterable
+from unittest.mock import expectedFailure, Mock, patch
 
 import aiohttp
 from aiosqlite import connect

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ lexicographically within each group. This will commonly look like:
 import re
 from pathlib import Path
 from typing import Iterable
-from unittest.mock import expectedFailure, Mock, patch
+from unittest.mock import call, Mock, patch
 
 import aiohttp
 from aiosqlite import connect

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -20,3 +20,7 @@ div.facebook a, div.facebook a:hover, div.facebook-badges a:hover {
     color: #777;
     border: none;
 }
+
+dl.function, dl.attribute, dl.class, dl.method, dl.field-list, dl.data {
+    margin-bottom: 15px;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,19 @@
+API Reference
+=============
+
+Simple API
+----------
+
+.. module:: usort
+
+.. autofunction:: usort_path
+.. autoclass:: Result
+.. autoclass:: SortWarning
+
+Advanced API
+------------
+
+.. autofunction:: usort
+.. autofunction:: usort_file
+.. autofunction:: usort_stdin
+.. autoclass:: Config

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,6 @@ templates_path = ["_templates"]
 exclude_patterns = []
 
 autodoc_default_options = {
-    "show-inheritance": True,
     "members": True,
     "undoc-members": True,
 }

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -100,7 +100,7 @@ After running µsort, these imports would be merged together::
     from unittest import expectedFailure, TestCase, skip
 
 Individual names imported from that module will be deduplicated, and any associated
-inline comments will be merged at best effort (see `Comments`_ for association details).
+inline comments will be merged at best effort (see `Merging Comments`_ below).
 µsort will ensure that it keeps one and only one of each unique imported name,
 including any aliases. Given the following import statements::
 
@@ -129,7 +129,7 @@ Merging Comments
 
 µsort will attempt to preserve any comments associated with an import statement, or any
 imported names, and merge them with comments from the same name or same part from the
-the other statement. See `Comment Associations`_ for details on association rules.
+the other statement. See `Associations`_ for details on comment association rules.
 
 For sake of simplicity in the implementation, comments are not deduplicated, and will
 be reproduced in their entirety, including the comment prefix. Their final order is
@@ -170,8 +170,12 @@ Both statements will be merged, and comments will follow their respective elemen
         # mu
     )  # zeta  # nu
 
-Comment Associations
---------------------
+
+Comments
+--------
+
+Associations
+^^^^^^^^^^^^
 
 When moving or merging imports, µsort will attempt to associate and preserve comments
 based on simple heuristics for ownership:
@@ -212,6 +216,49 @@ import statement, it may be easier to follow this example::
 
 Be aware that blank lines do not impact association rules, and the blank lines in the
 example above are purely for clarity.
+
+.. note:: block comments at the beginning of a source file will not be associated with
+    any statement, due to behavior in LibCST [#libcst405]_.
+
+    This means the `# alpha` comment below will not move with the import statement
+    it would otherwise be associated with::
+
+        #!/usr/bin/env python
+
+        # alpha
+        import foo
+        import bar
+
+    This would unexpectedly result in the following file after sorting::
+
+        #!/usr/bin/env python
+
+        # alpha
+        import bar
+        import foo
+
+    To guarantee the expected behavior, a simple docstring can be added at the top of
+    the file, and any comments after the docstring will be associated with the
+    appropriate statements::
+
+        #!/usr/bin/env python
+        """ This is a module """
+
+        # alpha
+        import foo
+        import bar
+
+    This would then allow µsort to correctly move the comment as expected::
+
+        #!/usr/bin/env python
+        """ This is a module """
+
+        import bar
+        # alpha
+        import foo
+
+    .. [#libcst405] https://github.com/Instagram/LibCST/issues/405
+
 
 Configuration
 -------------

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -174,6 +174,20 @@ Both statements will be merged, and comments will follow their respective elemen
 Comments
 --------
 
+Directives
+^^^^^^^^^^
+
+µsort will obey simple `# usort:skip` directives to prevent moving import statements,
+including moving any other statements across the skipped statement::
+
+    import math
+
+    import important_thing  # usort: skip
+
+    import difflib
+
+See `Import Blocks`_ for details on how this affects sorting behavior.
+
 Associations
 ^^^^^^^^^^^^
 
@@ -217,7 +231,7 @@ import statement, it may be easier to follow this example::
 Be aware that blank lines do not impact association rules, and the blank lines in the
 example above are purely for clarity.
 
-.. note:: block comments at the beginning of a source file will not be associated with
+.. note:: Block comments at the beginning of a source file will not be associated with
     any statement, due to behavior in LibCST [#libcst405]_.
 
     This means the `# alpha` comment below will not move with the import statement
@@ -263,8 +277,13 @@ example above are purely for clarity.
 Import Blocks
 -------------
 
-µsort uses a set of simple heuristics to detect "blocks" of imports, and will
-only rearrange imports within these distinct blocks.
+µsort groups imports into one or more "blocks" of imports. µsort will only move imports
+within the distinct block they were originally located. The boundaries of blocks are
+treated as "barriers", and imports will never move across these boundaries from one
+block to another.
+
+µsort uses a set of simple heuristics to define blocks of imports, based on common
+idioms and special behaviors that ensure a reasonable level of "safety" when sorting.
 
 Comment Directives
 ^^^^^^^^^^^^^^^^^^
@@ -281,6 +300,13 @@ containing the directives, which will remain unchanged::
 Both ``# usort:skip`` and ``# isort:skip`` (with any amount of whitespace),
 will trigger this behavior, so existing comments intended for isort will still
 work with µsort.
+
+.. note:: The ``# isort:skip_file`` directive **is ignored** by µsort, and there
+    is no supported equivalent. We believe that µsort's behavior is safe enough that
+    all files can be safely sortable, given an appropriate `configuration`_ that
+    includes any known modules with import-time side effects.
+
+    If there are files you absolutely don't want sorted; don't run µsort on them.
 
 Statements
 ^^^^^^^^^^

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -260,92 +260,6 @@ example above are purely for clarity.
     .. [#libcst405] https://github.com/Instagram/LibCST/issues/405
 
 
-Configuration
--------------
-
-µsort shouldn't require configuration for most projects, but offers some basic
-options to customize sorting and categorization behaviors.
-
-:file:`pyproject.toml`
-^^^^^^^^^^^^^^^^^^^^^^
-
-The preferred method of configuring µsort is in your project's
-:file:`pyproject.toml`, in the ``tool.usort`` table.
-When sorting each file, µsort will look for the "nearest" :file:`pyproject.toml`
-to the file being sorted, looking upwards until the project root is found, or
-until the root of the filesystem is reached.
-
-``[tool.usort]``
-%%%%%%%%%%%%%%%%
-
-The following options are valid for the main ``tool.usort`` table:
-
-.. attribute:: categories
-    :type: List[str]
-    :value: ["future", "standard_library", "third_party", "first_party"]
-
-    If given, this list of categories overrides the default list of categories
-    that µsort provides. New categories may be added, but any of the default
-    categories *not* listed here will be removed.
-
-.. attribute:: default_category
-    :type: str
-    :value: "third_party"
-
-    The default category to classify any modules that aren't already known by
-    µsort as part of the standard library or otherwise listed in the
-    ``tool.usort.known`` table.
-
-.. attribute:: side_effect_modules
-    :type: List[str]
-
-    An optional list of known modules that have dangerous import-time side
-    effects. Any module in this list will create implicit block separators from
-    any import statement matching one of these modules.
-
-    See :ref:`side-effect-imports`.
-
-.. attribute:: first_party_detection
-    :type: bool
-    :value: true
-
-    Whether to run a heuristic to detect the top-level name of the file being sorted,
-    and consider that name as first-party.  This heuristic happens after other options
-    are loaded, so such names cannot be overridden to another category if this is
-    enabled.
-
-.. attribute:: merge_imports
-    :type: bool
-    :value: true
-
-    Whether to merge sequential imports from the same base module.
-    See `Merging`_ for details on how this works.
-
-
-``[tool.usort.known]``
-%%%%%%%%%%%%%%%%%%%%%%
-
-The ``tool.usort.known`` table allows for providing a custom list of known
-modules for each category defined by :attr:`categories` above. These modules
-should be a list of module names assigned to a property named matching the
-category they should be assigned to. If a module is listed under multiple
-catergories, the last category it appears in will take precedence.
-
-As an example, this creates a fifth category "numpy", and adds both :mod:`numpy`
-and :mod:`pandas` to the known modules list for the "numpy" category, as well
-as adding the :mod:`example` module to the "first_party" category:
-
-.. code-block:: toml
-
-    [tool.usort]
-    categories = ["future", "standard_library", numpy", "third_party", "first_party"]
-    default_category = "third_party"
-
-    [tool.usort.known]
-    numpy = ["numpy", "pandas"]
-    first_party = ["example"]
-
-
 Import Blocks
 -------------
 
@@ -439,6 +353,92 @@ can be added to the :attr:`side_effect_modules` configuration option:
 This may result in less-obvious sorting results for users unaware of the
 context, so it is recommended to use this sparingly. The ``list-imports``
 command may be useful for understanding how this affects your source files.
+
+
+Configuration
+-------------
+
+µsort shouldn't require configuration for most projects, but offers some basic
+options to customize sorting and categorization behaviors.
+
+:file:`pyproject.toml`
+^^^^^^^^^^^^^^^^^^^^^^
+
+The preferred method of configuring µsort is in your project's
+:file:`pyproject.toml`, in the ``tool.usort`` table.
+When sorting each file, µsort will look for the "nearest" :file:`pyproject.toml`
+to the file being sorted, looking upwards until the project root is found, or
+until the root of the filesystem is reached.
+
+``[tool.usort]``
+%%%%%%%%%%%%%%%%
+
+The following options are valid for the main ``tool.usort`` table:
+
+.. attribute:: categories
+    :type: List[str]
+    :value: ["future", "standard_library", "third_party", "first_party"]
+
+    If given, this list of categories overrides the default list of categories
+    that µsort provides. New categories may be added, but any of the default
+    categories *not* listed here will be removed.
+
+.. attribute:: default_category
+    :type: str
+    :value: "third_party"
+
+    The default category to classify any modules that aren't already known by
+    µsort as part of the standard library or otherwise listed in the
+    ``tool.usort.known`` table.
+
+.. attribute:: side_effect_modules
+    :type: List[str]
+
+    An optional list of known modules that have dangerous import-time side
+    effects. Any module in this list will create implicit block separators from
+    any import statement matching one of these modules.
+
+    See :ref:`side-effect-imports`.
+
+.. attribute:: first_party_detection
+    :type: bool
+    :value: true
+
+    Whether to run a heuristic to detect the top-level name of the file being sorted,
+    and consider that name as first-party.  This heuristic happens after other options
+    are loaded, so such names cannot be overridden to another category if this is
+    enabled.
+
+.. attribute:: merge_imports
+    :type: bool
+    :value: true
+
+    Whether to merge sequential imports from the same base module.
+    See `Merging`_ for details on how this works.
+
+
+``[tool.usort.known]``
+%%%%%%%%%%%%%%%%%%%%%%
+
+The ``tool.usort.known`` table allows for providing a custom list of known
+modules for each category defined by :attr:`categories` above. These modules
+should be a list of module names assigned to a property named matching the
+category they should be assigned to. If a module is listed under multiple
+catergories, the last category it appears in will take precedence.
+
+As an example, this creates a fifth category "numpy", and adds both :mod:`numpy`
+and :mod:`pandas` to the known modules list for the "numpy" category, as well
+as adding the :mod:`example` module to the "first_party" category:
+
+.. code-block:: toml
+
+    [tool.usort]
+    categories = ["future", "standard_library", numpy", "third_party", "first_party"]
+    default_category = "third_party"
+
+    [tool.usort.known]
+    numpy = ["numpy", "pandas"]
+    first_party = ["example"]
 
 
 Troubleshooting

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -54,8 +54,8 @@ Within each category, imports are sorted first by "style" of import statement:
 * "basic" imports (``import foo``)
 * "from" imports (``from foo import bar``)
 
-And lastly, imports of the same style are sorted lexicographically by source
-module name, and then by name of element being imported.
+And lastly, imports of the same style are sorted lexicographically, and case-
+insensitively, by source module name, and then by name of element being imported.
 
 Altogether, this will result each block of imports sorted roughly according
 to this example, for a module in the namespace :mod:`something`::

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -68,6 +68,7 @@ to this example, for a module in the namespace :mod:`something`::
     import sys
     from datetime import date, datetime, timedelta
     from pathlib import Path
+    from unittest import expectedFailure, TestCase, skip
 
     # third-party
     import requests
@@ -77,7 +78,7 @@ to this example, for a module in the namespace :mod:`something`::
     # first-party
     from something import other_function, some_function
     from . import some_module
-    from .other_module import some_name, that_thing
+    from .other_module import SomeClass, some_thing, TestFixture
 
 
 Merging
@@ -88,7 +89,17 @@ of the same style from the same module, and merge them into a single statement.
 Individual names imported from that module will be deduplicated, and any associated
 inline comments will be merged.
 
-*todo*
+For a simple example, starting with the following imports::
+
+    from unittest import expectedFailure, skip
+    from typing import List, Dict
+    from unittest import TestCase
+    from typing import Set, Mapping
+
+After running µsort, these imports would be merged together::
+
+    from typing import Dict, List, Mapping, Set
+    from unittest import expectedFailure, TestCase, skip
 
 If desired, this behavior can be disabled in your project `configuration`_.
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -177,7 +177,7 @@ Comments
 Directives
 ^^^^^^^^^^
 
-µsort will obey simple `# usort:skip` directives to prevent moving import statements,
+µsort will obey simple ``#usort:skip`` directives to prevent moving import statements,
 including moving any other statements across the skipped statement::
 
     import math
@@ -187,6 +187,18 @@ including moving any other statements across the skipped statement::
     import difflib
 
 See `Import Blocks`_ for details on how this affects sorting behavior.
+
+.. note:: 
+    For compatibility with existing codebases previously using isort, the
+    ``#isort:skip`` directive is also supported, with the same behavior as
+    ``#usort:skip``.
+    
+    However, the ``#isort:skip_file`` directive **is ignored** by µsort, and there
+    is no supported equivalent. We believe that µsort's behavior is safe enough that
+    all files can be safely sortable, given an appropriate `configuration`_ that
+    includes any known modules with import-time side effects.
+
+    If there are files you absolutely don't want sorted; don't run µsort on them.
 
 Associations
 ^^^^^^^^^^^^
@@ -297,16 +309,9 @@ containing the directives, which will remain unchanged::
 
     import difflib
 
-Both ``# usort:skip`` and ``# isort:skip`` (with any amount of whitespace),
+Both ``#usort:skip`` and ``#isort:skip`` (with any amount of whitespace),
 will trigger this behavior, so existing comments intended for isort will still
 work with µsort.
-
-.. note:: The ``# isort:skip_file`` directive **is ignored** by µsort, and there
-    is no supported equivalent. We believe that µsort's behavior is safe enough that
-    all files can be safely sortable, given an appropriate `configuration`_ that
-    includes any known modules with import-time side effects.
-
-    If there are files you absolutely don't want sorted; don't run µsort on them.
 
 Statements
 ^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
     :maxdepth: 2
 
     guide
+    api
 
 .. toctree::
     :hidden:

--- a/usort/__init__.py
+++ b/usort/__init__.py
@@ -11,9 +11,14 @@ except ImportError:
     __version__ = "dev"
 
 from .api import usort, usort_bytes, usort_file, usort_path, usort_stdin, usort_string
+from .config import Config
+from .types import Result, SortWarning
 
 __all__ = [
     "__version__",
+    "Config",
+    "Result",
+    "SortWarning",
     "usort",
     "usort_bytes",
     "usort_file",

--- a/usort/__init__.py
+++ b/usort/__init__.py
@@ -10,10 +10,11 @@ try:
 except ImportError:
     __version__ = "dev"
 
-from .api import usort_bytes, usort_file, usort_path, usort_stdin, usort_string
+from .api import usort, usort_bytes, usort_file, usort_path, usort_stdin, usort_string
 
 __all__ = [
     "__version__",
+    "usort",
     "usort_bytes",
     "usort_file",
     "usort_path",

--- a/usort/api.py
+++ b/usort/api.py
@@ -117,7 +117,7 @@ def usort_file(path: Path, *, write: bool = False) -> Result:
 
 def usort_path(path: Path, *, write: bool = False) -> Iterable[Result]:
     """
-    For a given path, format it, or any .py files in it, and yield Result objects
+    For a given path, format it, or any .py files in it, and yield :class:`Result` s.
     """
     with timed(f"total for {path}"):
         with timed(f"walking {path}"):

--- a/usort/api.py
+++ b/usort/api.py
@@ -117,7 +117,7 @@ def usort_file(path: Path, *, write: bool = False) -> Result:
 
 def usort_path(path: Path, *, write: bool = False) -> Iterable[Result]:
     """
-    For a given path, format it, or any .py files in it, and yield :class:`Result` s.
+    For a given path, format it, or any python files in it, and yield :class:`Result` s.
     """
     with timed(f"total for {path}"):
         with timed(f"walking {path}"):


### PR DESCRIPTION
- [x] Adds `usort()`, `Config`, and `SortWarning` to the public API.
- [x] Adds a new "API Reference" section to the sidebar.
- [x] Divides the public API into "simple" and "advanced" sections.
- [x] Documents import merging semantics
- [ ] Adds detailed descriptions to public API
- [ ] Document first party semantics (Fix #30)
- [x] Document isort:skip/skip_file directives (Fix #28)

Preview docs: https://usort--91.org.readthedocs.build/en/91/