### PR TITLE
Improved skip directive support

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -186,7 +186,19 @@ including moving any other statements across the skipped statement::
 
     import difflib
 
-See `Import Blocks`_ for details on how this affects sorting behavior.
+Comment directives must be on the first or last line of multi-line imports::
+
+    from side_effect import (  # usort:skip  # here
+        thing_one,
+        thing_two,
+    )  # usort:skip  # or here
+
+Directives are also allowed anywhere in a comment, but must include another ``#``
+character if they are not the first element::
+
+    import side_effect  # noqa: F401  # usort:skip
+
+See `Import Blocks`_ for details on how skip directives affect sorting behavior.
 
 .. note:: 
     For compatibility with existing codebases previously using isort, the
@@ -312,6 +324,8 @@ containing the directives, which will remain unchanged::
 Both ``#usort:skip`` and ``#isort:skip`` (with any amount of whitespace),
 will trigger this behavior, so existing comments intended for isort will still
 work with µsort.
+
+See `directives`_ for details on supported comment directives.
 
 Statements
 ^^^^^^^^^^

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -800,6 +800,65 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_skip_directives(self) -> None:
+        """Test both usort:skip and isort:skip on single line imports"""
+        self.assertUsortResult(
+            """
+                from os import path
+                import functools  # usort: skip
+                import asyncio
+                from collections import defaultdict  # isort:skip
+                from asyncio import gather
+            """,
+            """
+                from os import path
+                import functools  # usort: skip
+                import asyncio
+                from collections import defaultdict  # isort:skip
+                from asyncio import gather
+            """,
+        )
+
+    def test_skip_directives_after_noqa(self) -> None:
+        """Test that skips are obeyed, even if they aren't the first directive"""
+        self.assertUsortResult(
+            """
+                from os import path
+                import functools  # noqa  # usort: skip
+                import asyncio
+            """,
+            """
+                from os import path
+                import functools  # noqa  # usort: skip
+                import asyncio
+            """,
+        )
+
+    def test_skip_directives_multiline(self) -> None:
+        """Validate that skip work on both first and last line of multiline imports"""
+        self.assertUsortResult(
+            """
+                from unittest.mock import (
+                    Mock, MagicMock, call, patch, sentinel, ANY,
+                )  # usort:skip
+                from functools import wraps
+                from asyncio import (  # usort:skip
+                    gather, wait,
+                )
+                from collections import defaultdict
+            """,
+            """
+                from unittest.mock import (
+                    Mock, MagicMock, call, patch, sentinel, ANY,
+                )  # usort:skip
+                from functools import wraps
+                from asyncio import (  # usort:skip
+                    gather, wait,
+                )
+                from collections import defaultdict
+            """,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -50,6 +50,10 @@ class UsortStringFunctionalTest(unittest.TestCase):
         config = config or DEFAULT_CONFIG
         result1 = usort(before.encode(), config)  # first pass
         result2 = usort(result1.output, config)  # enforce stable sorting on second pass
+        if result1.error:
+            raise result1.error
+        if result2.error:
+            raise result2.error
         if result2.output != result1.output:
             self.fail(
                 "µsort result was not stable on second pass:\n\n"


### PR DESCRIPTION
* Allow `#usort:skip` on the first line of multi-line imports
* Support `#usort:skip` after other comments/directives
* Document supported directive locations/positions
* Add test cases that fail on main but pass with PR
* Better error reporting from functional tests when exceptions occur during sorting

Fixes #27 

Docs preview: https://usort--108.org.readthedocs.build/en/108/guide.html#comments