### PR TITLE
Document use of black line-length config

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -472,6 +472,23 @@ as adding the :mod:`example` module to the "first_party" category:
     first_party = ["example"]
 
 
+``[tool.black]``
+%%%%%%%%%%%%%%%%
+
+µsort will also recognize the following options for `Black`_:
+
+.. attribute:: line-length
+    :type: int
+    :value: 88
+
+    The target line length configured for Black will also be used by µsort when
+    rendering imports after merging and sorting. Imports that fit within this length,
+    including indentation and comments, will be rendered on a single line. Otherwise,
+    imports will be rendered as multi-line imports, with a single name per line.
+
+.. _Black: https://black.readthedocs.io
+
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
We use `tool.black.line-length` from `pyroject.toml` when deciding if imports should be expanded to multiline or not. This mentions that in the configuration section.

Docs preview: https://usort--109.org.readthedocs.build/en/109/guide.html#tool-black