### PR TITLE
Add new `excludes` configuration option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ autodoc_member_order = "groupwise"
 highlight_language = "python3"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "pathspec": ("https://python-path-specification.readthedocs.io/en/latest/", None),
     "stdlib_list": ("https://python-stdlib-list.readthedocs.io/en/latest/", None),
 }
 master_doc = "index"

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -461,6 +461,32 @@ The following options are valid for the main ``tool.usort`` table:
     Whether to merge sequential imports from the same base module.
     See `Merging`_ for details on how this works.
 
+.. attribute:: excludes
+    :type: List[str]
+
+    List of "gitignore" style filename patterns to exclude when sorting paths.
+    This will supplement any ignored paths from the project root's ``.gitignore`` file,
+    and any file or directory that matches these patterns will not be sorted.
+
+    Example:
+
+    .. code-block:: toml
+
+        [tool.usort]
+        excludes = [
+            "test/fixtures/",
+            "*_generated.py",
+        ]
+
+    This configuration would match and exclude the following files:
+
+    * ``test/fixtures/something_good.py``
+    * ``foo/test/fixtures/something_bad.py``
+    * ``foo/client/robot_generated.py``
+
+    See the :std:doc:`pathspec <pathspec:index>` and
+    :py:class:`GitWildPatchPattern <pathspec.patterns.gitwildmatch.GitWildMatchPattern>`
+    documentation for details of what patterns are allowed and how they are applied.
 
 ``[tool.usort.known]``
 %%%%%%%%%%%%%%%%%%%%%%

--- a/usort/config.py
+++ b/usort/config.py
@@ -58,6 +58,9 @@ class Config:
     # Whether to merge imports when sorting
     merge_imports: bool = True
 
+    # gitignore-style filename patterns to exclude when sorting entire directories
+    excludes: List[str] = field(default_factory=list)
+
     # Needed for formatting final imports
     line_length: int = 88
 
@@ -155,6 +158,8 @@ class Config:
             self.first_party_detection = tbl["first_party_detection"]
         if "merge_imports" in tbl:
             self.merge_imports = tbl["merge_imports"]
+        if "excludes" in tbl:
+            self.excludes = tbl["excludes"]
 
         for cat, names in tbl.get("known", {}).items():
             typed_cat = Category(cat)

--- a/usort/tests/config.py
+++ b/usort/tests/config.py
@@ -171,6 +171,31 @@ foo = ["numpy", "pandas"]
             # from foo.bar import bazzy
             self.assertFalse(config.is_side_effect_import("foo.bar", ["bazzy"]))
 
+    def test_config_excludes(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            d_path = Path(d)
+            (d_path / "foo").mkdir(parents=True)
+            (d_path / "foo" / "bar.py").write_text("import os")
+
+            with self.subTest("default config"):
+                (d_path / "foo" / "pyproject.toml").write_text("")
+                conf = Config.find(d_path / "foo" / "bar.py")
+                self.assertEqual([], conf.excludes)
+
+            with self.subTest("with black config"):
+                (d_path / "foo" / "pyproject.toml").write_text(
+                    """\
+[tool.usort]
+excludes = [
+    "fixtures/",
+    "*generated.py",
+]
+"""
+                )
+                conf = Config.find(d_path / "foo" / "bar.py")
+                expected = ["fixtures/", "*generated.py"]
+                self.assertEqual(expected, conf.excludes)
+
     def test_black_line_length(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             d_path = Path(d)


### PR DESCRIPTION
Supports reading a list of gitignore patterns from
`tool.usort.excludes`, and passes those values to trailrunner when
walking paths in `usort_path()`.

Includes tests and documentation updates to match.

Fixes #62 

Docs preview: https://usort--111.org.readthedocs.build/en/111/guide.html#excludes