### PR TITLE
Remove or defer use of PositionProvider metadata when sorting

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -345,6 +345,7 @@ class ImportSortingTransformer(cst.CSTTransformer):
     def visit_IndentedBlock(self, node: cst.IndentedBlock) -> Optional[bool]:
         node_indent = node.indent
         self.indent += self.default_indent if node_indent is None else node_indent
+        return True
 
     def leave_IndentedBlock(
         self, original_node: cst.IndentedBlock, updated_node: cst.IndentedBlock


### PR DESCRIPTION
Tracks indentation from indented nodes while walking the tree, rather than using `PositionProvider` metadata. For warnings about implicit block splitting and shadowed imports, defers resolving the metadata until after sorting is finished, and only if warnings were generated.

Overall, running `usort --benchmark diff <path/to/libcst/libcst>` shows approximately 20-30% performance improvement:

From main:
```
(.venv) jreese@butterfree ~/workspace/usort main  » usort --benchmark diff $workspace/libcst/libcst | grep total
total for /Users/jreese/workspace/libcst/libcst:   10497973 µs
```

With PR:
```
(.venv) jreese@butterfree ~/workspace/usort no-position-metadata  » usort --benchmark diff $workspace/libcst/libcst | grep total
total for /Users/jreese/workspace/libcst/libcst:   7079384 µs
```