### PR TITLE
Fix #128: handle single line from-imports with parens

### DIFF
--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -564,6 +564,18 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_single_line_parens(self) -> None:
+        self.assertUsortResult(
+            """
+                from delta import echo, foxtrot
+                from alfa import (bravo, charlie)  # hello
+            """,
+            """
+                from alfa import bravo, charlie  # hello
+                from delta import echo, foxtrot
+            """,
+        )
+
     def test_single_line_import_long_comment(self) -> None:
         """
         Basic import statements can't be reflowed to multiple lines

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -53,22 +53,24 @@ def import_comments_from_node(node: cst.SimpleStatementLine) -> ImportComments:
 
     if isinstance(imp, cst.ImportFrom):
         if imp.lpar:
-            # from foo import (  # THIS PART
-            #     bar,
-            # )
-            ws = cst.ensure_type(imp.lpar.whitespace_after, cst.ParenthesizedWhitespace)
-            if ws.first_line.comment:
-                comments.first_inline.extend(
-                    split_inline_comment(ws.first_line.comment.value)
-                )
+            if isinstance(imp.lpar.whitespace_after, cst.ParenthesizedWhitespace):
+                ws = imp.lpar.whitespace_after
 
-            # from foo import (
-            #     # THIS PART
-            #     bar,
-            # )
-            comments.initial.extend(
-                line.comment.value for line in ws.empty_lines if line.comment
-            )
+                # from foo import (  # THIS PART
+                #     bar,
+                # )
+                if ws.first_line.comment:
+                    comments.first_inline.extend(
+                        split_inline_comment(ws.first_line.comment.value)
+                    )
+
+                # from foo import (
+                #     # THIS PART
+                #     bar,
+                # )
+                comments.initial.extend(
+                    line.comment.value for line in ws.empty_lines if line.comment
+                )
 
             assert imp.rpar is not None
             if isinstance(imp.rpar.whitespace_before, cst.ParenthesizedWhitespace):


### PR DESCRIPTION
Adds a functional test covering broken behavior in 1.0, with a fix for that behavior.