### PR TITLE
Add "why µsort" page to docs, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 **Safe, minimal import sorting for Python projects.**
 
+[![documentation](https://readthedocs.org/projects/usort/badge/?version=stable)](https://usort.readthedocs.io/en/stable/?badge=stable)
 [![version](https://img.shields.io/pypi/v/usort.svg)](https://pypi.org/project/usort)
-[![changelog](https://img.shields.io/badge/change-log-blue.svg)](https://github.com/facebookexperimental/usort/blob/main/CHANGELOG.md)
+[![changelog](https://img.shields.io/badge/change-log-blue.svg)](https://usort.readthedocs.io/en/latest/changelog.html)
 [![license](https://img.shields.io/pypi/l/usort.svg)](https://github.com/facebookexperimental/usort/blob/main/LICENSE)
-[![code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 μsort is a safe, minimal import sorter. Its primary goal is to make no "dangerous"
-changes to code, and to make no changes on code style. This is achieved by detecting
-distinct "blocks" of imports that are the most likely to be safely interchangeable, and
-only reordering imports within these blocks without altering formatting. Code style
-is left as an exercise for linters and formatters.
+changes to code. This is achieved by detecting distinct "blocks" of imports that are
+the most likely to be safely interchangeable, and only reordering imports within these
+blocks without altering formatting. Code style is left as an exercise for linters
+and formatters.
 
 Within a block, µsort will follow common Python conventions for grouping imports based
 on source (standard library, third-party, first-party, or relative), and then sorting
@@ -47,8 +47,8 @@ In this case, µsort detects two blocks–separated by the call to `filterwarnin
 and will only sort imports inside of each block. Running µsort on this code
 will generate no changes, because each block is already sorted.
 
-Imports can be excluded from blocks using the `# usort:skip` directive, or with
-`# isort:skip` for compatibility with existing codebases. µsort will leave
+Imports can be excluded from blocks using the `#usort:skip` directive, or with
+`#isort:skip` for compatibility with existing codebases. µsort will leave
 these imports unchanged, and treat them as block separators.
 
 See the [User Guide][] for more details about how blocks are detected,
@@ -89,4 +89,4 @@ $ usort check <path>
 μsort is MIT licensed, as found in the [LICENSE][] file.
 
 [LICENSE]: https://github.com/facebookexperimental/usort/tree/main/LICENSE
-[User Guide]: https://usort.readthedocs.io/
+[User Guide]: https://usort.readthedocs.io/en/stable/guide.html

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -297,6 +297,7 @@ example above are purely for clarity.
 
     .. [#libcst405] https://github.com/Instagram/LibCST/issues/405
 
+.. _import-blocks:
 
 Import Blocks
 -------------
@@ -533,7 +534,7 @@ Troubleshooting
 ---------------
 
 If µsort behavior is unexpected, or you would like to see how µsort detects
-blocks in your code, the `list-imports` command may help.
+blocks in your code, the ``list-imports`` command may help.
 
 Given the file ``test.py``::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,9 +3,14 @@
 
 .. toctree::
     :hidden:
-    :maxdepth: 2
+    :maxdepth: 1
 
     why
+
+.. toctree::
+    :hidden:
+    :maxdepth: 2
+
     guide
     api
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@
     :hidden:
     :maxdepth: 2
 
+    why
     guide
     api
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,4 +1,111 @@
 Why µsort?
 ==========
 
-µsort was originally designed with safety as the primary goal–"first, do no harm".
+µsort was originally designed with safety as the top priority–"first, do no harm".
+Sorting imports should never result in breaking functionality of the module.
+
+µsort is designed to be as safe as possible when running on enterprise scale codebases
+with tens or hundreds of thousands of Python source files, and can be used either as a
+standalone formatting tool or linter, or as part of automated codemod toolchains or
+CI/CD pipelines. It is currently used in production by Meta for sorting all formatted
+Python sources, with daily codemods enforcing sorting on all covered files.
+
+µsort achieves this by making a best effort at understanding common patterns in the
+structure of modules, and splitting the code into smaller blocks of sortable imports.
+By sorting imports only within these blocks, µsort preserves the locations any
+intermediary code that could affect the context or behavior of subsequent imports,
+and sorts modules safely with a minimal number of comment directives (ideally none).
+When in doubt, µsort will prefer to leave imports in place, rather than risk breaking
+functionality of the module being sorted.
+
+See the :doc:`User Guide <guide>` for details.
+
+
+Design Goals
+------------
+
+µsort prefers the simplest code necessary, with predictable and understandable logic,
+to sort imports while maintaining safety of the output with minimal directives from
+developers writing code:
+
+- Simple dataclasses and sorting methods, optimizing for readable and maintainable
+  code rather than absolute performance.
+
+- A single primary code path, to reduce the amount of code and number of test cases
+  needed to guarantee safety.
+
+- Stable sorting methods that should always result in the same final output, even
+  after multiple passes. This is enforced as part of the functional test suite.
+
+- `LibCST`_ for parsing files and modifying syntax trees.
+  µsort transforms CST nodes into dataclasses, then back to CST nodes after sorting.
+  This guarantees grammatical correctness of both the input file and the generated
+  output. Support for future grammar or syntax changes is the responsibility of LibCST.
+
+- No support for configuring output style. µsort works best when run before a
+  dedicated code formatter like `Black`_ for enforcing style choices. µsort does use
+  the configured line length for Black when rendering imports on one or more lines.
+
+- No vendored code. All dependencies are satisfied from PyPI, with liberal version
+  constraints whenever possible.
+
+
+Non-Goals
+---------
+
+There are some features of alternative import sorters that µsort will not offer:
+
+- Broad behavioral changes when sorting files, like moving imports from below a function
+  to the top of the file during development. Guaranteeing safety and stability while
+  also moving imports between blocks is difficult and hard to reason about in code.
+
+- Removing unused imports. This would require µsort to also consume and understand the
+  functionality of each file to accurately know which imports are unused, which would
+  increase the amount of code and testing needed to guarantee safety. Furthemore, the
+  possibility for import-time side effects in removed imports makes this operation
+  potentially dangerous in subtle ways.
+
+- Configurable output style. More options means more code paths to follow, and more
+  test cases needed to cover all possible outputs. This is better left for dedicated
+  code formatters like `Black`_.
+
+- Python 2 support. µsort's use of strict parsing and manipulation of syntax trees
+  makes supporting Python 2 grammar elements a non-starter.
+
+
+Comparison to isort
+-------------------
+
+Unlike `isort`_, µsort only sorts imports within individual "blocks" of imports,
+inferred based on a number of heuristics (see :ref:`Import Blocks <import-blocks>`
+for details). µsort will not attempt to move imports outside of these blocks, or
+across any blocks of code that aren't import statements.
+
+For example, µsort detects two distinct blocks of imports in the following code::
+
+    import sys
+    sys.path.append("/path/to/libs")
+
+    import foo
+
+Appending to :data:`sys.path`, by definition, changes the behavior of future imports.
+µsort treats this snippet of code as correctly sorted, while isort will attempt to move
+the ``import foo`` statement to the top, breaking the module if ``foo`` isn't available
+in the default search path, and requiring addition of ``isort: skip`` directives to
+maintain functionality.
+
+µsort uses case-insensitive, lexicographical sorting for both module names and imported
+items within each statement. This means uppercase or titlecase names are mixed with
+lowercase names, but this also provides a more consistent ordering of names, and
+ensures that ``frog``, ``Frog``, and ``FROG`` will always sort next to each other:
+
+    from unittest.mock import ANY, AsyncMock, call, DEFAULT, Mock, patch
+
+Lastly, µsort operates on a parsed syntax tree, rather than reading and parsing each
+line of text from each file. This guarantees that µsort is modifying the actual Python
+syntax elements, along with any associated comments, and generating grammatically
+correct results after sorting.
+
+.. _LibCST: https://libcst.readthedocs.io
+.. _Black: https://black.readthedocs.io
+.. _isort: https://pycqa.github.io/isort/

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,0 +1,4 @@
+Why µsort?
+==========
+
+µsort was originally designed with safety as the primary goal–"first, do no harm".


### PR DESCRIPTION
Adds new page to docs site, "Why µsort":

- [x] Overview of safety, use at scale, and how
- [x] Design goals
- [x] Non-goals
- [x] Comparison to isort 

Preview docs: https://usort--130.org.readthedocs.build/en/130/

Closes #116 