### PR TITLE
Recalculate sort_key after sorting import items

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -261,6 +261,7 @@ class ImportSorter:
         # Sort items within each remaining statement
         for imp in imports:
             imp.items.sort()
+            imp.calculate_sort_key()
 
         return imports
 

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -628,6 +628,21 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_sorting_mixed_category_imports(self) -> None:
+        self.assertUsortResult(
+            """
+                import os, attr
+                import difflib
+                import third_party
+            """,
+            """
+                import difflib
+
+                import attr, os
+                import third_party
+            """,
+        )
+
     def test_merging_import_items(self) -> None:
         self.assertUsortResult(
             """

--- a/usort/types.py
+++ b/usort/types.py
@@ -218,7 +218,7 @@ class SortableImport:
 
         return results
 
-    def __attrs_post_init__(self) -> None:
+    def calculate_sort_key(self) -> None:
         top: Optional[str] = None
         ndots = 0
 
@@ -238,6 +238,9 @@ class SortableImport:
             is_from_import=bool(self.stem),
             ndots=ndots,
         )
+
+    def __attrs_post_init__(self) -> None:
+        self.calculate_sort_key()
 
 
 @dataclass(repr=False)


### PR DESCRIPTION
Fixes #145 when sorting basic imports with multiple items from
different categories.