### PR TITLE
Don't use trailrunner to format exactly one file

### DIFF
--- a/usort/api.py
+++ b/usort/api.py
@@ -131,7 +131,7 @@ def usort_path(path: Path, *, write: bool = False) -> Iterable[Result]:
             paths = list(walk(path, excludes=config.excludes))
 
         fn = partial(usort_file, write=write)
-        if len(paths) == 1:  
+        if len(paths) == 1:
             results = [fn(paths[0])]  # shave off multiprocessing overhead
         else:
             results = [v for v in run(paths, fn).values()]

--- a/usort/api.py
+++ b/usort/api.py
@@ -131,7 +131,10 @@ def usort_path(path: Path, *, write: bool = False) -> Iterable[Result]:
             paths = list(walk(path, excludes=config.excludes))
 
         fn = partial(usort_file, write=write)
-        results = [v for v in run(paths, fn).values()]
+        if len(paths) == 1:  
+            results = [fn(paths[0])]  # shave off multiprocessing overhead
+        else:
+            results = [v for v in run(paths, fn).values()]
         return results
 
 


### PR DESCRIPTION
See #159

This optimises for a common use case when only one file is provided.

This change might belong to `trailrunner` repo as well. 