### PR TITLE
Skip deep copying CST after parsing

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -26,7 +26,7 @@ class ImportSorter:
         self.path = path
         self.warning_nodes: List[Tuple[cst.CSTNode, str]] = []
         self.warnings: List[SortWarning] = []
-        self.wrapper = cst.MetadataWrapper(module)
+        self.wrapper = cst.MetadataWrapper(module, unsafe_skip_copy=True)
         self.transformer = ImportSortingTransformer(config, module, self)
 
     def has_skip_comment(self, comment: Optional[cst.Comment]) -> bool:


### PR DESCRIPTION
This is safe to do, because `module` always comes from the parser, so there are no duplicate nodes in the tree.

Here's a rough benchmark showing the benefits (`usort-skipcopy` has both the native libcst parser and this PR turned on):

|Snippet Code|Snippet Name|Runs|Mean|Median|Min|Max|Standard Deviation|
|---|---|---|---|---|---|---|---|
|usort.api.usort(src, usort_conf)|usort-default|20|143.9 ms|143.8 ms|142.67 ms|145.18 ms|927.37 µs|
|os.environ["LIBCST_PARSER_TYPE"] = "native"; usort.api.usort(src, usort_conf)|usort-native|28|106.09 ms|106.06 ms|105.68 ms|106.73 ms|282.61 µs|
|os.environ["USORT_SKIP_COPY"] = "true"; usort.api.usort(src, usort_conf)|usort-skipcopy|35|76.36 ms|76.15 ms|75.61 ms|77.52 ms|679.27 µs|


produced with
```
python -m fastero -s "import os, sys,usort; usort_conf = usort.Config.find(); src=open('usort/sorting.py').read()" -n usort-default "usort.api.usort(src, usort_conf)" -n usort-native 'os.environ["LIBCST_PARSER_TYPE"] = "native"; usort.api.usort(src, usort_conf)' -n usort-skipcopy 'os.environ["USORT_SKIP_COPY"] = "true"; usort.api.usort(src, usort_conf)'
```
after changing the `unsafe_skip_copy` argument to `"USORT_SKIP_COPY" in os.environ`

![perf](https://user-images.githubusercontent.com/66740/173253576-ab0bfbea-9b22-4fc6-b239-041b7cfeeacb.svg)


