### PR TITLE
Skip visiting CST nodes that cannot have import statements

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -351,6 +351,9 @@ class ImportSortingTransformer(cst.CSTTransformer):
     def get_original_node(self, node: cst.CSTNode) -> cst.CSTNode:
         return self.statement_map.get(node, node)
 
+    def on_visit(self, node: cst.CSTNode) -> bool:
+        return not isinstance(node, (cst.BaseExpression, cst.BaseSmallStatement))
+
     def leave_SimpleStatementLine(
         self,
         original_node: cst.SimpleStatementLine,


### PR DESCRIPTION
This should prevent a large class of `RecursionError`s popping up for deeply nested syntax trees. On top of that, it makes usort ~37% faster even on smallish files like `sorting.py`.

```
usort-default: usort.api.usort(src, usort_conf)
  Time  (mean ± σ):       100.57 ms ±   4.18 ms
  Range (min  … max):      96.31 ms … 125.62 ms    [runs: 100]
usort-optimized: usort.api.usort(src, usort_opt)
  Time  (mean ± σ):       73.59 ms ±  2.57 ms
  Range (min  … max):     70.97 ms … 79.81 ms    [runs: 100]

Summary:
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Bar Chart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ usort-default   [96.31 ms]: ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆ ┃
┃ usort-optimized [70.97 ms]: ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆              ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (lower is better) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  usort-optimized is the fastest.
    1.37 (1.36 … 1.57) times faster than usort-default
```