### PR TITLE
Make sure indentation is tracked

### DIFF
--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -352,7 +352,9 @@ class ImportSortingTransformer(cst.CSTTransformer):
         return self.statement_map.get(node, node)
 
     def on_visit(self, node: cst.CSTNode) -> bool:
-        return not isinstance(node, (cst.BaseExpression, cst.BaseSmallStatement))
+        if isinstance(node, (cst.BaseExpression, cst.BaseSmallStatement)):
+            return False
+        return super().on_visit(node)
 
     def leave_SimpleStatementLine(
         self,

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -542,6 +542,24 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_multi_line_expand_but_not_very_long(self) -> None:
+        """
+        This test makes sure indentation is taken into account properly.
+        Without indentation, these lines wouldn't be too long.
+        """
+        self.assertUsortResult(
+            """
+                if foo:
+                    from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa import bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            """,
+            """
+                if foo:
+                    from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa import (
+                        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+                    )
+            """,
+        )
+
     def test_multi_line_expand_inner_function(self) -> None:
         self.assertUsortResult(
             """


### PR DESCRIPTION
https://github.com/facebookexperimental/usort/pull/187 broke the logic that keeps track of indentation for the purposes of line length tracking by not letting `visit_IndentedBlock` run in the transformer.

This affected (import) lines that are long enough to fit `line_length` without the indentation, but too long if we count indentation too.

This PR adds a test case for this situation.