### PR TITLE
Proposal #B: Normalize blank lines within categories

### DIFF
--- a/usort/cli.py
+++ b/usort/cli.py
@@ -13,7 +13,6 @@ import click
 from moreorless.click import echo_color_unified_diff
 
 from usort.translate import render_node
-
 from . import __version__
 from .api import usort_path, usort_stdin
 from .config import Config

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -347,11 +347,10 @@ numpy = ["numpy", "pandas"]
         """
         self.assertUsortResult(content, content, config)
 
-    def test_match_black_blank_line_before_comment(self) -> None:
+    def test_collapse_blank_line_before_comment(self) -> None:
         content = """
             import a
             import b
-
             # comment
             import c
         """
@@ -787,7 +786,6 @@ numpy = ["numpy", "pandas"]
             """,
             """
                 import a
-
                 # one
                 # apple
                 from foo import (  # two  # banana
@@ -1007,6 +1005,83 @@ excludes = [
                 self.assertNotIn(result.path, excluded_paths)
                 self.assertEqual(sorted_content, result.output.replace(b"\r\n", b"\n"))
             self.assertEqual(len(sorted_paths), len(results))
+
+    def test_sorting_with_normalized_blank_lines(self) -> None:
+        self.assertUsortResult(
+            """
+                import math
+
+                import beta
+                from . import foo
+                import alpha
+            """,
+            """
+                import math
+
+                import alpha
+                import beta
+
+                from . import foo
+            """,
+        )
+
+    def test_sorting_with_extra_blank_lines(self) -> None:
+        self.assertUsortResult(
+            """
+                import math
+
+
+                import beta
+                from . import foo
+
+                import alpha
+            """,
+            """
+                import math
+
+                import alpha
+                import beta
+
+                from . import foo
+            """,
+        )
+
+    def test_sorting_with_many_extra_blank_lines(self) -> None:
+        self.assertUsortResult(
+            """
+                import math
+
+                import gamma
+                import alpha
+                # boring
+                import kappa
+
+
+                # special
+                import beta
+
+                from . import foo
+
+                import zeta
+
+            """,
+            """
+                import math
+
+                import alpha
+
+                # special
+                import beta
+
+                import gamma
+                # boring
+                import kappa
+                import zeta
+
+                from . import foo
+
+            """,
+        )
 
 
 if __name__ == "__main__":

--- a/usort/tests/sorting.py
+++ b/usort/tests/sorting.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import libcst as cst
 
 from ..config import Config
-
 from ..sorting import ImportSorter
 
 

--- a/usort/tests/types.py
+++ b/usort/tests/types.py
@@ -258,7 +258,7 @@ class TypesTest(unittest.TestCase):
                                 SortableImportItem(name='bar', asname=None, comments=ImportItemComments(before=[], inline=[], following=[])),
                                 SortableImportItem(name='baz', asname='buzz', comments=ImportItemComments(before=[], inline=[], following=[])),
                             ],
-                            comments = ImportComments(before=[], first_inline=[], initial=[], inline=[], final=[], last_inline=[]),
+                            comments = ImportComments(before=[], first_inline=[], initial=[], inline=[], final=[], last_inline=[], blanks_before=[], blanks_after=[]),
                             indent = '    ',
                         ),
                         SortableImport(
@@ -267,7 +267,7 @@ class TypesTest(unittest.TestCase):
                             items = [
                                 SortableImportItem(name='core', asname=None, comments=ImportItemComments(before=[], inline=[], following=[])),
                             ],
-                            comments = ImportComments(before=[], first_inline=[], initial=[], inline=[], final=[], last_inline=[]),
+                            comments = ImportComments(before=[], first_inline=[], initial=[], inline=[], final=[], last_inline=[], blanks_before=[], blanks_after=[]),
                             indent = '    ',
                         ),
                     ],

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -49,7 +49,7 @@ def import_comments_from_node(node: cst.SimpleStatementLine) -> ImportComments:
         if line.comment:
             comments.before.append(line.comment.value)
         else:
-            comments.before.append("")
+            comments.blanks_before.append("")
 
     if isinstance(imp, cst.ImportFrom):
         if imp.lpar:
@@ -235,7 +235,7 @@ def import_to_node_single(imp: SortableImport, module: cst.Module) -> cst.BaseSt
         cst.EmptyLine(indent=True, comment=cst.Comment(line))
         if line.startswith("#")
         else cst.EmptyLine(indent=False)
-        for line in imp.comments.before
+        for line in [*imp.comments.blanks_before, *imp.comments.before]
     ]
 
     trailing_whitespace = cst.TrailingWhitespace()

--- a/usort/types.py
+++ b/usort/types.py
@@ -16,6 +16,7 @@ from .config import CAT_FIRST_PARTY, Config
 from .util import stem_join, Timing, top_level_name
 
 COMMENT_INDENT = "  "
+ONE_BLANK = [""]
 
 
 def case_insensitive_ordering(text: Optional[str]) -> Optional[str]:
@@ -80,6 +81,8 @@ class ImportComments:
     inline: List[str] = field(factory=list)  # Only when no trailing comma
     final: List[str] = field(factory=list)
     last_inline: List[str] = field(factory=list)
+    blanks_before: List[str] = field(factory=list)
+    blanks_after: List[str] = field(factory=list)
 
     def __add__(self, other: "ImportComments") -> "ImportComments":
         if not isinstance(other, ImportComments):
@@ -92,6 +95,8 @@ class ImportComments:
             inline=[*self.inline, *other.inline],
             final=[*self.final, *other.final],
             last_inline=[*self.last_inline, *other.last_inline],
+            blanks_before=[*self.blanks_before, *other.blanks_before],
+            blanks_after=[*self.blanks_after, *other.blanks_after],
         )
 
 
@@ -250,6 +255,7 @@ class SortableBlock:
 
     imports: List[SortableImport] = field(factory=list)
     imported_names: Dict[str, str] = field(factory=dict)
+    initial_blanks: List[str] = field(factory=list)
 
     def __repr__(self) -> str:
         imports = indent("\n".join(f"{imp!r}," for imp in self.imports), "        ")


### PR DESCRIPTION
More complicated alternative for handling #163:

- Uniformly removes blank lines between imports of the same category
- Except when the import has both a preceding standalone comment and one or more preceding or following blank lines