### PR TITLE
Treat lines with multiple statements as barriers

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -383,6 +383,14 @@ logging::
 
     import other_module
 
+Similarly, any line with multiple statements separated by semicolons will also
+create an implicit block separator. µsort will defer to a dedicated formatter
+for correctly splitting those statements onto separate lines::
+
+    import zipfile
+    import sys; import re  # <-- implicit block separator
+    import ast
+
 Shadowed Imports
 ^^^^^^^^^^^^^^^^
 

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -56,14 +56,16 @@ class ImportSorter:
                 return False
 
             # N.b. `body` is a list, because the SimpleStatementLine might have
-            # semicolons.  We only look at the first, which is probably the most
-            # dangerous thing in here.
+            # semicolons. We treat lines with multiple statements as unsortable.
+            # This is the safest and easiest thing to do.
             #
             # If black is run, it will put the semicolon pieces on different lines,
             # but we don't want to do that until we reflow and handle directives
             # like noqa.  TODO do that before calling is_sortable_import, and assert
             # that it's not a compound statement line.
-            if isinstance(stmt.body[0], cst.ImportFrom):
+            if len(stmt.body) > 1:
+                return False
+            elif isinstance(stmt.body[0], cst.ImportFrom):
                 # from foo import (  # usort:skip
                 #     bar,
                 # )

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -186,6 +186,24 @@ class UsortStringFunctionalTest(unittest.TestCase):
             """,
         )
 
+    def test_semicolons(self) -> None:
+        self.assertUsortResult(
+            """
+                import zipfile
+                import re
+                import sys; print(sys)
+                import urllib
+                import difflib
+            """,
+            """
+                import re
+                import zipfile
+                import sys; print(sys)
+                import difflib
+                import urllib
+            """,
+        )
+
     def test_dot_handling(self) -> None:
         # Test that 'from .. import b' comes before 'from ..a import foo'
         self.assertUsortResult(

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -36,7 +36,7 @@ def name_to_node(name: str) -> Union[cst.Name, cst.Attribute]:
 def import_comments_from_node(node: cst.SimpleStatementLine) -> ImportComments:
     comments = ImportComments()
 
-    assert len(node.body) == 1
+    assert len(node.body) == 1, "lines with multiple statements are unsupported"
     assert isinstance(node.body[0], (cst.Import, cst.ImportFrom))
     imp: Union[cst.Import, cst.ImportFrom] = node.body[0]
 


### PR DESCRIPTION
Since we can't easily reason about or handle lines with multiple
statements (separated by semicolons), this improves usort's behavior by
treating them as unsortable, effectively becoming barriers between
blocks of imports. This fixes an issue where assertions failed when
transforming nodes into dataclasses.

Fixes #203