### PR TITLE
FEAT: Add command line flag to specify location of usort config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,32 +69,43 @@ $ pip install usort
 To format one or more files or directories in-place:
 
 ```shell-session
-$ usort format <path> [<path> ...]
+$ usort format [--config config/usort.toml] <path> [<path> ...]
 ```
 
 To generate a diff of changes without modifying files:
 
 ```shell-session
-$ usort diff <path>
+$ usort diff [--config config/usort.toml] <path>
 ```
 
 To just validate that files are formatted correctly, like during CI:
 
 ```shell-session
-$ usort check <path>
+$ usort check [--config config/usort.toml] <path>
+```
+
+### Explicit configuration files
+
+All CLI commands accept `--config` to point at an alternate TOML configuration file.
+If omitted µsort falls back to the discovery of the nearest `pyproject.toml`.
+
+```shell-session
+$ usort format --config config/usort.toml <path>
 ```
 
 ### pre-commit
 
 µsort provides a [pre-commit](https://pre-commit.com/) hook. To enforce sorted
 imports before every commit, add the following to your `.pre-commit-config.yaml`
-file:
+file. If you keep µsort settings in a custom TOML file, pass the same
+`--config` flag via `args`:
 
 ```yaml
 - repo: https://github.com/facebook/usort
   rev: v1.0.7
   hooks:
     - id: usort
+      args: ["--config", "config/usort.toml"]
 ```
 
 ## License

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -12,19 +12,19 @@ To format one or more files or directories in-place:
 
 .. code-block:: shell-session
 
-    $ usort format <path> [<path> ...]
+    $ usort format [--config config/usort.toml] <path> [<path> ...]
 
 To generate a diff of changes without modifying files:
 
 .. code-block:: shell-session
 
-    $ usort diff <path> [<path> ...]
+    $ usort diff [--config config/usort.toml] <path> [<path> ...]
 
 µsort can also be used to validate formatting as part of CI:
 
 .. code-block:: shell-session
 
-    $ usort check <path> [<path> ...]
+    $ usort check [--config config/usort.toml] <path> [<path> ...]
 
 
 Sorting
@@ -461,6 +461,17 @@ The preferred method of configuring µsort is in your project's
 When sorting each file, µsort will look for the "nearest" :file:`pyproject.toml`
 to the file being sorted, looking upwards until the project root is found, or
 until the root of the filesystem is reached.
+
+Explicit config files
+%%%%%%%%%%%%%%%%%%%%%
+
+You can specify a configuration file using the ``--config`` CLI option to point 
+commands like ``format``, ``check``, ``diff`` and ``list-imports`` at a specific
+TOML file:
+
+.. code-block:: shell-session
+
+    $ usort format --config config/usort.toml src/
 
 ``[tool.usort]``
 %%%%%%%%%%%%%%%%

--- a/usort/tests/__init__.py
+++ b/usort/tests/__init__.py
@@ -5,7 +5,12 @@
 
 from .cli import CliTest
 from .config import ConfigTest
-from .functional import BasicOrderingTest, UsortStringFunctionalTest
+from .functional import (
+    BasicOrderingTest,
+    UsortFileFirstPartyTest,
+    UsortStdinFirstPartyTest,
+    UsortStringFunctionalTest,
+)
 from .sorting import SplitTest
 from .stdlibs import StdlibsTest
 from .translate import IsSortableTest, SortableImportTest
@@ -16,6 +21,8 @@ __all__ = [
     "CliTest",
     "ConfigTest",
     "BasicOrderingTest",
+    "UsortFileFirstPartyTest",
+    "UsortStdinFirstPartyTest",
     "UsortStringFunctionalTest",
     "IsSortableTest",
     "SortableImportTest",


### PR DESCRIPTION
This adds a new `--config` flag to set a specific toml file to be used as config. 

Closes #31