### PR TITLE
FEAT: honour [tool.usort] line length option.

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -537,6 +537,17 @@ The following options are valid for the main ``tool.usort`` table:
     Whether to merge sequential imports from the same base module.
     See `Merging`_ for details on how this works.
 
+.. attribute:: line_length
+    :type: int
+    :value: 88
+
+    The maximum line length µsort should target when rendering imports. Imports
+    that fit within this limit, including indentation and inline comments, will
+    collapse to a single line. Longer imports render as multi-line imports with
+    one name per line. When both ``[tool.usort]`` ``line_length`` and
+    ``[tool.black]`` ``line-length`` are provided, the value from Black takes
+    precedence.
+
 .. attribute:: excludes
     :type: List[str]
 
@@ -597,10 +608,11 @@ as adding the :mod:`example` module to the "first_party" category:
     :type: int
     :value: 88
 
-    The target line length configured for Black will also be used by µsort when
-    rendering imports after merging and sorting. Imports that fit within this length,
-    including indentation and comments, will be rendered on a single line. Otherwise,
-    imports will be rendered as multi-line imports, with a single name per line.
+    The target line length configured for Black takes precedence over
+    ``[tool.usort]`` ``line_length``. µsort uses this value when rendering imports
+    after merging and sorting. Imports that fit within this length, including
+    indentation and comments, will be rendered on a single line. Otherwise, imports
+    will be rendered as multi-line imports, with a single name per line.
 
 .. _Black: https://black.readthedocs.io
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -44,7 +44,8 @@ developers writing code:
 
 - No support for configuring output style. µsort works best when run before a
   dedicated code formatter like `Black`_ for enforcing style choices. µsort does use
-  the configured line length for Black when rendering imports on one or more lines.
+  its configured line length when rendering imports on one or more lines, honoring
+  ``[tool.usort]`` ``line_length`` unless ``[tool.black]`` ``line-length`` is present.
   We use `µfmt`_ to combine µsort and Black into a single, atomic formatting step.
 
 - No vendored code. All dependencies are satisfied from PyPI, with unbound version

--- a/usort/config.py
+++ b/usort/config.py
@@ -169,6 +169,10 @@ class Config:
             self.merge_imports = bool(tbl["merge_imports"])
         if "excludes" in tbl:
             self.excludes = tbl["excludes"]
+        if "line_length" in tbl:
+            self.line_length = int(tbl["line_length"])
+        elif "line-length" in tbl:
+            self.line_length = int(tbl["line-length"])
 
         for cat, names in tbl.get("known", {}).items():
             typed_cat = Category(cat)


### PR DESCRIPTION
Currently to set a line length option the only way is to define `[tool.black]`.
This PR introduces support for having the same option alternatively defined in the proper [tool.usort] section.
It currently gives precedence of black over usort configuration.