### PR TITLE
Prevent one line comments from being re-formatted

### DIFF
--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -331,6 +331,18 @@ numpy = ["numpy", "pandas"]
                     from something import nothing
             """,
         )
+    
+    def test_white_space_pytorch_example(self) -> None:
+        config = replace(DEFAULT_CONFIG, preserve_inline_comments=True)
+        self.assertUsortResult(
+            """
+            from package.test_save_load import TestSaveLoad  # noqa: F401
+            """, 
+            """
+            from package.test_save_load import TestSaveLoad  # noqa: F401
+            """,
+            config
+        )
 
     def test_case_insensitive_sorting(self) -> None:
         content = """

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -331,17 +331,17 @@ numpy = ["numpy", "pandas"]
                     from something import nothing
             """,
         )
-    
+
     def test_white_space_pytorch_example(self) -> None:
         config = replace(DEFAULT_CONFIG, preserve_inline_comments=True)
         self.assertUsortResult(
             """
             from package.test_save_load import TestSaveLoad  # noqa: F401
-            """, 
+            """,
             """
             from package.test_save_load import TestSaveLoad  # noqa: F401
             """,
-            config
+            config,
         )
 
     def test_case_insensitive_sorting(self) -> None:

--- a/usort/translate.py
+++ b/usort/translate.py
@@ -258,9 +258,10 @@ def import_to_node(
     if config.magic_commas and imp.stem and imp.trailing_comma:
         return import_to_node_multi(imp, module)
 
-    # If preserve_inline_comments is enabled and any item has inline comments,
-    # use multi-line format to preserve them
-    if config.preserve_inline_comments and imp.stem:
+    # If preserve_inline_comments is enabled and multiple items have inline comments,
+    # use multi-line format to preserve them. Single-item imports can keep comments
+    # on the same line.
+    if config.preserve_inline_comments and imp.stem and len(imp.items) > 1:
         has_item_comments = any(item.comments.inline for item in imp.items)
         if has_item_comments:
             return import_to_node_multi(imp, module)


### PR DESCRIPTION
One line import statements were being reformatted from:

```
from package.test_save_load import TestSaveLoad  # noqa: F401
```
to 
```
from package.test_save_load  import (
   TestSaveLoad # noqa: F401
)
```

Which is not what we want. This PR makes sure we're not reformatting this case unecessarily. 