### PR TITLE
Fix usort_file write condition to check error instead of output truth…

### DIFF
--- a/usort/api.py
+++ b/usort/api.py
@@ -103,7 +103,7 @@ def usort_file(path: Path, *, write: bool = False) -> Result:
         data = path.read_bytes()
         result = usort(data, config, path)
 
-        if result.output and write:
+        if result.error is None and write:
             path.write_bytes(result.output)
 
         return result


### PR DESCRIPTION
…iness

`if result.output and write:` treated b"" as "don't write", which would silently skip the write for a legitimately empty sorted file, or mask any future bug that produces empty output for non-empty input. Check `result.error is None` instead, which is the correct signal that sorting succeeded.