### PR TITLE
Fix Result.trace: capture traceback at the exception site

### DIFF
--- a/usort/api.py
+++ b/usort/api.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import sys
+import traceback
 from functools import partial
 from pathlib import Path
 from typing import Iterable, Optional, Set, Tuple, Union
@@ -45,6 +46,7 @@ def usort(data: bytes, config: Config, path: Optional[Path] = None) -> Result:
             path=path,
             content=data,
             error=e,
+            trace="".join(traceback.format_exception(type(e), e, e.__traceback__)),
             timings=get_timings(),
         )
 
@@ -112,6 +114,7 @@ def usort_file(path: Path, *, write: bool = False) -> Result:
         return Result(
             path=path,
             error=e,
+            trace="".join(traceback.format_exception(type(e), e, e.__traceback__)),
             timings=get_timings(),
         )
 

--- a/usort/types.py
+++ b/usort/types.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
-import traceback
 from pathlib import Path
 from textwrap import dedent, indent
 from typing import Dict, List, Optional, Sequence
@@ -47,12 +45,6 @@ class Result:
     trace: str = ""
     timings: Sequence[Timing] = ()
     warnings: Sequence[SortWarning] = ()
-
-    def __attrs_post_init__(self) -> None:
-        if self.error:
-            exc_type, exc, tb = sys.exc_info()
-            if exc_type is not None:
-                self.trace = "".join(traceback.format_exception(exc_type, exc, tb))
 
 
 @dataclass


### PR DESCRIPTION
sys.exc_info() always returned (None, None, None) inside __attrs_post_init__ because the except clause had already exited by the time Result was constructed.  Move traceback capture to each except block in api.py using e.__traceback__, and remove the now-dead __attrs_post_init__ from Result (along with the sys/traceback imports that were only needed for it).