### PR TITLE
Fix AND→OR guards in SortableImport{Item}.__add__

### DIFF
--- a/usort/tests/types.py
+++ b/usort/tests/types.py
@@ -116,6 +116,26 @@ class TypesTest(unittest.TestCase):
             ):
                 a += 10  # type: ignore
 
+    def test_sortable_import_item_add_name_mismatch_raises(self) -> None:
+        # `bar` and `baz` are different names — adding must raise even when asnames match.
+        # The AND bug allowed this silently: (name!=name=True) AND (asname!=asname=False) = False.
+        a = types.SortableImportItem(name="bar", asname="")
+        b = types.SortableImportItem(name="baz", asname="")
+        self.assertEqual(
+            a.asname, b.asname
+        )  # confirm same asname (the AND bug trigger)
+        with self.assertRaises(ValueError):
+            _ = a + b
+
+    def test_sortable_import_item_add_asname_mismatch_raises(self) -> None:
+        # `bar as x` and `bar as y` are distinct aliases — adding must raise even when names match.
+        # The AND bug allowed this silently: (name!=name=False) AND (asname!=asname=True) = False.
+        a = types.SortableImportItem(name="bar", asname="x")
+        b = types.SortableImportItem(name="bar", asname="y")
+        self.assertEqual(a.name, b.name)  # confirm same name (the AND bug trigger)
+        with self.assertRaises(ValueError):
+            _ = a + b
+
     def test_sortable_import_add(self) -> None:
         a = types.SortableImport(
             stem="foo",
@@ -213,6 +233,25 @@ class TypesTest(unittest.TestCase):
                 TypeError, "unsupported.+'SortableImport'.+'int'"
             ):
                 a += 10  # type: ignore
+
+    def test_sortable_import_add_stem_mismatch_raises(self) -> None:
+        # `from os import ...` and `from sys import ...` have the same sort_key (both
+        # are stdlib from-imports) but different stems — adding must raise.
+        # The AND bug allowed this silently: (key!=key=False) AND (stem!=stem=True) = False.
+        a = types.SortableImport(
+            stem="os",
+            items=[types.SortableImportItem(name="path", asname="")],
+        )
+        b = types.SortableImport(
+            stem="sys",
+            items=[types.SortableImportItem(name="argv", asname="")],
+        )
+        self.assertEqual(
+            a.sort_key, b.sort_key
+        )  # confirm same sort_key (the AND bug trigger)
+        self.assertNotEqual(a.stem, b.stem)
+        with self.assertRaises(ValueError):
+            _ = a + b
 
     def test_sortable_import_trailing_comma(self) -> None:
         imp = types.SortableImport(

--- a/usort/types.py
+++ b/usort/types.py
@@ -120,7 +120,7 @@ class SortableImportItem:
         if not isinstance(other, SortableImportItem):
             return NotImplemented
 
-        if self.name != other.name and self.asname != other.asname:
+        if self.name != other.name or self.asname != other.asname:
             raise ValueError("name and asname must match")
 
         return SortableImportItem(
@@ -173,7 +173,7 @@ class SortableImport:
         if not isinstance(other, SortableImport):
             return NotImplemented
 
-        if self.sort_key != other.sort_key and self.stem != other.stem:
+        if self.sort_key != other.sort_key or self.stem != other.stem:
             raise ValueError("sort_key and stem must match")
 
         # Combine the items from the other import statement with items from this import.


### PR DESCRIPTION
Both guards used `and`, so they only raised when *both* fields mismatched simultaneously.  `bar as x` + `bar as y` (same name, different asname) and `from os …` + `from sys …` (same sort_key, different stem) silently succeeded.  Change to `or` so either mismatch raises.  Add three regression tests that target each of the two previously-dead raise sites.